### PR TITLE
feat: implement Python Client SDK (Phase 4.2)

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -378,6 +378,79 @@ PR: #14
 
 ---
 
+## 2025-02-06 - Phase 4.2 Python Client SDK
+
+### Summary
+
+Implemented a Python Client SDK (`vgate-client`) providing both synchronous and asynchronous clients for interacting with the V-Gate API, with automatic retry, rate-limit handling, and typed responses.
+
+### What Was Done
+
+| Feature | Description |
+|---------|-------------|
+| **VGate (Sync Client)** | Synchronous client using `httpx.Client` |
+| **AsyncVGate (Async Client)** | Asynchronous client using `httpx.AsyncClient` |
+| **Chat Completions** | `client.chat.create()` with OpenAI-compatible response models |
+| **Embeddings** | `client.embeddings.create()` with typed response |
+| **Auto Retry** | Exponential backoff on 429/5xx with configurable `max_retries` |
+| **Rate Limit Parsing** | Automatic parsing of `X-RateLimit-*` and `Retry-After` headers |
+| **Typed Exceptions** | `AuthenticationError`, `RateLimitError`, `ServerError`, `ConnectionError` |
+| **Pydantic Models** | Full request/response model coverage matching server API |
+| **Context Manager** | `with VGate() as client:` / `async with AsyncVGate() as client:` |
+
+### Architecture
+
+```
+vgate-client/
+├── pyproject.toml              # Package metadata (PEP 621)
+├── vgate_client/
+│   ├── __init__.py             # Public API exports
+│   ├── client.py               # VGate (sync) + AsyncVGate (async)
+│   ├── models.py               # Pydantic request/response models
+│   └── exceptions.py           # Typed exception hierarchy
+└── tests/
+    ├── conftest.py             # Shared fixtures
+    ├── test_client.py          # Client tests (sync + async)
+    ├── test_models.py          # Model serialization tests
+    └── test_exceptions.py      # Exception hierarchy tests
+```
+
+### Usage
+
+```python
+from vgate_client import VGate
+
+client = VGate(base_url="http://localhost:8000", api_key="sk-vgate-dev-example")
+response = client.chat.create(
+    model="Qwen/Qwen2.5-1.5B-Instruct-AWQ",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(response.choices[0].message.content)
+client.close()
+```
+
+### Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `httpx>=0.25.0` | HTTP client (sync + async) |
+| `pydantic>=2.0.0` | Data validation and response models |
+
+### Test Results
+
+| Test Item | Status |
+|-----------|--------|
+| Sync client tests (19) | Pass |
+| Async client tests (9) | Pass |
+| Model tests (11) | Pass |
+| Exception tests (9) | Pass |
+| **Total (48)** | **Pass** |
+| Server tests (97) | Pass |
+
+Branch: `feat/phase4.2-python-sdk`
+
+---
+
 ## Project Progress
 
 - [x] **Phase 1**: Core MVP - Unified API Gateway
@@ -391,7 +464,7 @@ PR: #14
   - [x] 3.3 Security & Access Control
 - [ ] **Phase 4**: Ecosystem & Deployment
   - [x] 4.1 Containerization (Docker)
-  - [ ] 4.2 Python Client SDK
+  - [x] 4.2 Python Client SDK
   - [ ] 4.3 Kubernetes Deployment
 
 ---
@@ -400,6 +473,5 @@ PR: #14
 
 | Priority | Feature | Description |
 |----------|---------|-------------|
-| 1 | **Python Client SDK** | `pip install vgate-client` with `vgate.Chat.create()` API |
-| 2 | **Kubernetes Deployment** | Helm chart with HPA for auto-scaling |
-| 3 | **Multi-Worker Load Balancing** | Horizontal scaling with Ray/RunPod |
+| 1 | **Kubernetes Deployment** | Helm chart with HPA for auto-scaling |
+| 2 | **Multi-Worker Load Balancing** | Horizontal scaling with Ray/RunPod |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Optimized for memory-constrained environments (e.g., RTX 3060/4060).
 | **Rate Limiting** | Sliding window algorithm to prevent abuse |
 | **Configuration as Code** | YAML configuration with environment variable overrides |
 | **Docker Ready** | Multi-stage build with GPU and CPU targets |
+| **Python Client SDK** | `pip install` ready client with sync/async support |
 
 ---
 
@@ -109,6 +110,45 @@ curl http://localhost:8000/metrics
 ### Statistics
 ```bash
 curl http://localhost:8000/stats
+```
+
+### Python Client SDK
+
+```bash
+pip install ./vgate-client
+```
+
+```python
+from vgate_client import VGate
+
+# Synchronous client
+client = VGate(base_url="http://localhost:8000", api_key="sk-vgate-dev-example")
+
+response = client.chat.create(
+    model="Qwen/Qwen2.5-1.5B-Instruct-AWQ",
+    messages=[{"role": "user", "content": "What is 2+2?"}],
+    max_tokens=100,
+)
+print(response.choices[0].message.content)
+
+# Embeddings
+embedding = client.embeddings.create(model="mock-embedding-model", input="Hello world")
+
+# Health check
+health = client.health()
+
+client.close()
+```
+
+```python
+from vgate_client import AsyncVGate
+
+# Asynchronous client
+async with AsyncVGate(base_url="http://localhost:8000", api_key="sk-...") as client:
+    response = await client.chat.create(
+        model="Qwen/Qwen2.5-1.5B-Instruct-AWQ",
+        messages=[{"role": "user", "content": "Hello!"}],
+    )
 ```
 
 ---
@@ -262,6 +302,14 @@ V-Gate/
 │   ├── logging_config.py   # Structured logging
 │   ├── metrics.py          # Prometheus metrics
 │   └── security.py         # Authentication & rate limiting
+├── vgate-client/               # Python Client SDK
+│   ├── pyproject.toml
+│   ├── vgate_client/
+│   │   ├── __init__.py
+│   │   ├── client.py           # Sync & async clients
+│   │   ├── models.py           # Request/response models
+│   │   └── exceptions.py       # Error classes
+│   └── tests/
 ├── monitoring/
 │   └── prometheus.yml      # Prometheus configuration
 └── tests/
@@ -314,7 +362,7 @@ ruff check .
   - [x] 3.3 Security & Access Control
 - [x] **Phase 4**: Ecosystem & Deployment
   - [x] 4.1 Containerization (Docker)
-  - [ ] 4.2 Python Client SDK
+  - [x] 4.2 Python Client SDK
   - [ ] 4.3 Kubernetes Deployment
 
 ---

--- a/vgate-client/pyproject.toml
+++ b/vgate-client/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vgate-client"
+version = "0.1.0"
+description = "Python client SDK for V-Gate AI Model Serving Gateway"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.10"
+authors = [
+    {name = "V-Gate Contributors"},
+]
+keywords = ["ai", "gateway", "llm", "inference", "client"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "httpx>=0.25.0",
+    "pydantic>=2.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21",
+    "pytest-httpx>=0.30.0",
+    "ruff>=0.4.0",
+]
+
+[tool.setuptools.packages.find]
+include = ["vgate_client*"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/vgate-client/tests/conftest.py
+++ b/vgate-client/tests/conftest.py
@@ -1,0 +1,76 @@
+import pytest
+
+
+@pytest.fixture
+def chat_response_payload():
+    """Standard chat completion response matching server format."""
+    return {
+        "id": "chatcmpl-abc12345",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": "Qwen/Qwen2.5-1.5B-Instruct-AWQ",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "Hello! How can I help you?",
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 8,
+            "total_tokens": 18,
+        },
+    }
+
+
+@pytest.fixture
+def embedding_response_payload():
+    """Standard embedding response matching server format."""
+    return {
+        "object": "list",
+        "data": [
+            {
+                "object": "embedding",
+                "embedding": [0.1] * 1536,
+                "index": 0,
+            }
+        ],
+        "model": "mock-embedding-model",
+        "usage": {
+            "prompt_tokens": 4,
+            "completion_tokens": 0,
+            "total_tokens": 4,
+        },
+    }
+
+
+@pytest.fixture
+def health_response_payload():
+    return {"status": "ok", "version": "0.3.2"}
+
+
+@pytest.fixture
+def stats_response_payload():
+    return {
+        "batcher": {
+            "total_requests": 100,
+            "total_batches": 20,
+            "average_batch_size": 5.0,
+            "pending_requests": 0,
+            "total_deduplicated": 10,
+        },
+        "cache": {
+            "size": 50,
+            "maxsize": 1000,
+            "hits": 30,
+            "misses": 70,
+            "evictions": 0,
+            "hit_rate": 0.3,
+        },
+        "config": {},
+        "version": "0.3.2",
+    }

--- a/vgate-client/tests/test_client.py
+++ b/vgate-client/tests/test_client.py
@@ -1,0 +1,402 @@
+"""Tests for synchronous and asynchronous V-Gate clients."""
+
+import pytest
+import httpx
+import json
+
+from vgate_client import VGate, AsyncVGate
+from vgate_client.exceptions import (
+    AuthenticationError,
+    ConnectionError,
+    RateLimitError,
+    ServerError,
+    VGateError,
+)
+from vgate_client.models import ChatCompletion, EmbeddingResponse, HealthResponse
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _mock_response(
+    status_code: int = 200,
+    json_data: dict | None = None,
+    headers: dict | None = None,
+) -> httpx.Response:
+    """Build a fake httpx.Response."""
+    content = json.dumps(json_data or {}).encode()
+    return httpx.Response(
+        status_code=status_code,
+        content=content,
+        headers=headers or {},
+        request=httpx.Request("POST", "http://test/"),
+    )
+
+
+# ── Sync Client Tests ───────────────────────────────────────────────────────
+
+
+class TestVGateInit:
+    def test_default_base_url(self):
+        client = VGate()
+        assert client.base_url == "http://localhost:8000"
+        client.close()
+
+    def test_custom_base_url(self):
+        client = VGate(base_url="http://myhost:9000/")
+        assert client.base_url == "http://myhost:9000"
+        client.close()
+
+    def test_api_key_set_in_headers(self):
+        client = VGate(api_key="sk-test-123")
+        assert client._http.headers["Authorization"] == "Bearer sk-test-123"
+        client.close()
+
+    def test_no_api_key(self):
+        client = VGate()
+        assert "Authorization" not in client._http.headers
+        client.close()
+
+    def test_context_manager(self):
+        with VGate() as client:
+            assert client.base_url == "http://localhost:8000"
+
+
+class TestSyncChatCreate:
+    def test_success(self, chat_response_payload, monkeypatch):
+        client = VGate(api_key="sk-test")
+        mock_resp = _mock_response(200, chat_response_payload)
+        monkeypatch.setattr(client._http, "request", lambda *a, **kw: mock_resp)
+
+        result = client.chat.create(
+            model="Qwen/Qwen2.5-1.5B-Instruct-AWQ",
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+
+        assert isinstance(result, ChatCompletion)
+        assert result.choices[0].message.content == "Hello! How can I help you?"
+        assert result.usage.total_tokens == 18
+        client.close()
+
+    def test_custom_params(self, chat_response_payload, monkeypatch):
+        client = VGate()
+        calls = []
+
+        def mock_request(method, path, **kw):
+            calls.append(kw.get("json", {}))
+            return _mock_response(200, chat_response_payload)
+
+        monkeypatch.setattr(client._http, "request", mock_request)
+
+        client.chat.create(
+            model="m",
+            messages=[{"role": "user", "content": "test"}],
+            temperature=0.1,
+            top_p=0.5,
+            max_tokens=50,
+        )
+
+        sent = calls[0]
+        assert sent["temperature"] == 0.1
+        assert sent["top_p"] == 0.5
+        assert sent["max_tokens"] == 50
+        client.close()
+
+
+class TestSyncEmbeddingsCreate:
+    def test_success(self, embedding_response_payload, monkeypatch):
+        client = VGate()
+        mock_resp = _mock_response(200, embedding_response_payload)
+        monkeypatch.setattr(client._http, "request", lambda *a, **kw: mock_resp)
+
+        result = client.embeddings.create(model="m", input="hello world")
+        assert isinstance(result, EmbeddingResponse)
+        assert len(result.data[0].embedding) == 1536
+        client.close()
+
+
+class TestSyncHealth:
+    def test_success(self, health_response_payload, monkeypatch):
+        client = VGate()
+        mock_resp = _mock_response(200, health_response_payload)
+        monkeypatch.setattr(client._http, "get", lambda *a, **kw: mock_resp)
+
+        result = client.health()
+        assert isinstance(result, HealthResponse)
+        assert result.status == "ok"
+        assert result.version == "0.3.2"
+        client.close()
+
+
+class TestSyncStats:
+    def test_success(self, stats_response_payload, monkeypatch):
+        client = VGate()
+        mock_resp = _mock_response(200, stats_response_payload)
+        monkeypatch.setattr(client._http, "request", lambda *a, **kw: mock_resp)
+
+        result = client.stats()
+        assert result["batcher"]["total_requests"] == 100
+        client.close()
+
+
+class TestSyncErrorHandling:
+    def test_401_raises_auth_error(self, monkeypatch):
+        client = VGate()
+        mock_resp = _mock_response(401, {"detail": "Invalid API key"})
+        monkeypatch.setattr(client._http, "request", lambda *a, **kw: mock_resp)
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            client.chat.create(model="m", messages=[{"role": "user", "content": "hi"}])
+        assert exc_info.value.status_code == 401
+        client.close()
+
+    def test_429_raises_rate_limit_error(self, monkeypatch):
+        client = VGate(max_retries=0)
+        mock_resp = _mock_response(
+            429,
+            {"detail": "Rate limit exceeded"},
+            headers={"Retry-After": "30", "X-RateLimit-Limit": "100"},
+        )
+        monkeypatch.setattr(client._http, "request", lambda *a, **kw: mock_resp)
+
+        with pytest.raises(RateLimitError) as exc_info:
+            client.chat.create(model="m", messages=[{"role": "user", "content": "hi"}])
+        assert exc_info.value.retry_after == 30.0
+        client.close()
+
+    def test_500_raises_server_error(self, monkeypatch):
+        client = VGate(max_retries=0)
+        mock_resp = _mock_response(500, {"detail": "Internal error"})
+        monkeypatch.setattr(client._http, "request", lambda *a, **kw: mock_resp)
+
+        with pytest.raises(ServerError) as exc_info:
+            client.chat.create(model="m", messages=[{"role": "user", "content": "hi"}])
+        assert exc_info.value.status_code == 500
+        client.close()
+
+    def test_422_raises_vgate_error(self, monkeypatch):
+        client = VGate()
+        mock_resp = _mock_response(422, {"detail": "Validation error"})
+        monkeypatch.setattr(client._http, "request", lambda *a, **kw: mock_resp)
+
+        with pytest.raises(VGateError) as exc_info:
+            client.chat.create(model="m", messages=[{"role": "user", "content": "hi"}])
+        assert exc_info.value.status_code == 422
+        client.close()
+
+    def test_connection_error(self, monkeypatch):
+        client = VGate()
+
+        def raise_connect(*a, **kw):
+            raise httpx.ConnectError("Connection refused")
+
+        monkeypatch.setattr(client._http, "request", raise_connect)
+
+        with pytest.raises(ConnectionError):
+            client.chat.create(model="m", messages=[{"role": "user", "content": "hi"}])
+        client.close()
+
+    def test_health_connection_error(self, monkeypatch):
+        client = VGate()
+
+        def raise_connect(*a, **kw):
+            raise httpx.ConnectError("Connection refused")
+
+        monkeypatch.setattr(client._http, "get", raise_connect)
+
+        with pytest.raises(ConnectionError):
+            client.health()
+        client.close()
+
+
+class TestSyncRetry:
+    def test_retry_on_429(self, chat_response_payload, monkeypatch):
+        """Should retry on 429, then succeed."""
+        client = VGate(max_retries=2)
+        call_count = 0
+
+        def mock_request(*a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _mock_response(429, {"detail": "rate limited"}, {"Retry-After": "0"})
+            return _mock_response(200, chat_response_payload)
+
+        monkeypatch.setattr(client._http, "request", mock_request)
+        # Patch sleep to avoid waiting
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        result = client.chat.create(model="m", messages=[{"role": "user", "content": "hi"}])
+        assert isinstance(result, ChatCompletion)
+        assert call_count == 2
+        client.close()
+
+    def test_retry_on_500(self, chat_response_payload, monkeypatch):
+        """Should retry on 500, then succeed."""
+        client = VGate(max_retries=2)
+        call_count = 0
+
+        def mock_request(*a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _mock_response(500, {"detail": "server error"})
+            return _mock_response(200, chat_response_payload)
+
+        monkeypatch.setattr(client._http, "request", mock_request)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        result = client.chat.create(model="m", messages=[{"role": "user", "content": "hi"}])
+        assert isinstance(result, ChatCompletion)
+        assert call_count == 2
+        client.close()
+
+    def test_exhausted_retries_raises(self, monkeypatch):
+        """Should raise after max retries exceeded."""
+        client = VGate(max_retries=1)
+        monkeypatch.setattr(
+            client._http, "request",
+            lambda *a, **kw: _mock_response(500, {"detail": "down"}),
+        )
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        with pytest.raises(ServerError):
+            client.chat.create(model="m", messages=[{"role": "user", "content": "hi"}])
+        client.close()
+
+
+# ── Async Client Tests ───────────────────────────────────────────────────────
+
+
+class TestAsyncVGateInit:
+    @pytest.mark.asyncio
+    async def test_context_manager(self):
+        async with AsyncVGate() as client:
+            assert client.base_url == "http://localhost:8000"
+
+    @pytest.mark.asyncio
+    async def test_api_key(self):
+        client = AsyncVGate(api_key="sk-async-test")
+        assert client._http.headers["Authorization"] == "Bearer sk-async-test"
+        await client.close()
+
+
+class TestAsyncChatCreate:
+    @pytest.mark.asyncio
+    async def test_success(self, chat_response_payload, monkeypatch):
+        client = AsyncVGate()
+
+        async def mock_request(*a, **kw):
+            return _mock_response(200, chat_response_payload)
+
+        monkeypatch.setattr(client._http, "request", mock_request)
+
+        result = await client.chat.create(
+            model="Qwen/Qwen2.5-1.5B-Instruct-AWQ",
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+        assert isinstance(result, ChatCompletion)
+        assert result.choices[0].message.content == "Hello! How can I help you?"
+        await client.close()
+
+
+class TestAsyncEmbeddingsCreate:
+    @pytest.mark.asyncio
+    async def test_success(self, embedding_response_payload, monkeypatch):
+        client = AsyncVGate()
+
+        async def mock_request(*a, **kw):
+            return _mock_response(200, embedding_response_payload)
+
+        monkeypatch.setattr(client._http, "request", mock_request)
+
+        result = await client.embeddings.create(model="m", input="hello")
+        assert isinstance(result, EmbeddingResponse)
+        assert len(result.data[0].embedding) == 1536
+        await client.close()
+
+
+class TestAsyncHealth:
+    @pytest.mark.asyncio
+    async def test_success(self, health_response_payload, monkeypatch):
+        client = AsyncVGate()
+
+        async def mock_get(*a, **kw):
+            return _mock_response(200, health_response_payload)
+
+        monkeypatch.setattr(client._http, "get", mock_get)
+
+        result = await client.health()
+        assert isinstance(result, HealthResponse)
+        assert result.status == "ok"
+        await client.close()
+
+
+class TestAsyncErrorHandling:
+    @pytest.mark.asyncio
+    async def test_401(self, monkeypatch):
+        client = AsyncVGate()
+
+        async def mock_request(*a, **kw):
+            return _mock_response(401, {"detail": "Invalid API key"})
+
+        monkeypatch.setattr(client._http, "request", mock_request)
+
+        with pytest.raises(AuthenticationError):
+            await client.chat.create(model="m", messages=[{"role": "user", "content": "hi"}])
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_429(self, monkeypatch):
+        client = AsyncVGate(max_retries=0)
+
+        async def mock_request(*a, **kw):
+            return _mock_response(429, {"detail": "Rate limit"}, {"Retry-After": "10"})
+
+        monkeypatch.setattr(client._http, "request", mock_request)
+
+        with pytest.raises(RateLimitError) as exc_info:
+            await client.chat.create(model="m", messages=[{"role": "user", "content": "hi"}])
+        assert exc_info.value.retry_after == 10.0
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self, monkeypatch):
+        client = AsyncVGate()
+
+        async def raise_connect(*a, **kw):
+            raise httpx.ConnectError("Connection refused")
+
+        monkeypatch.setattr(client._http, "request", raise_connect)
+
+        with pytest.raises(ConnectionError):
+            await client.chat.create(model="m", messages=[{"role": "user", "content": "hi"}])
+        await client.close()
+
+
+class TestAsyncRetry:
+    @pytest.mark.asyncio
+    async def test_retry_on_429(self, chat_response_payload, monkeypatch):
+        client = AsyncVGate(max_retries=2)
+        call_count = 0
+
+        async def mock_request(*a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _mock_response(429, {"detail": "rate limited"}, {"Retry-After": "0"})
+            return _mock_response(200, chat_response_payload)
+
+        monkeypatch.setattr(client._http, "request", mock_request)
+
+        import asyncio
+
+        async def noop_sleep(_):
+            pass
+
+        monkeypatch.setattr(asyncio, "sleep", noop_sleep)
+
+        result = await client.chat.create(model="m", messages=[{"role": "user", "content": "hi"}])
+        assert isinstance(result, ChatCompletion)
+        assert call_count == 2
+        await client.close()

--- a/vgate-client/tests/test_exceptions.py
+++ b/vgate-client/tests/test_exceptions.py
@@ -1,0 +1,67 @@
+"""Tests for exception classes."""
+
+from vgate_client.exceptions import (
+    AuthenticationError,
+    ConnectionError,
+    RateLimitError,
+    ServerError,
+    VGateError,
+)
+
+
+class TestVGateError:
+    def test_base_error(self):
+        err = VGateError("something went wrong", status_code=400)
+        assert str(err) == "something went wrong"
+        assert err.status_code == 400
+        assert err.body is None
+
+    def test_with_body(self):
+        body = {"detail": "bad request"}
+        err = VGateError("bad", status_code=400, body=body)
+        assert err.body == body
+
+
+class TestAuthenticationError:
+    def test_is_vgate_error(self):
+        err = AuthenticationError("Invalid API key", status_code=401)
+        assert isinstance(err, VGateError)
+        assert err.status_code == 401
+
+
+class TestRateLimitError:
+    def test_retry_after(self):
+        err = RateLimitError("Rate limit exceeded", retry_after=30.0, status_code=429)
+        assert isinstance(err, VGateError)
+        assert err.retry_after == 30.0
+        assert err.status_code == 429
+
+    def test_no_retry_after(self):
+        err = RateLimitError("Rate limit exceeded", status_code=429)
+        assert err.retry_after is None
+
+
+class TestServerError:
+    def test_basic(self):
+        err = ServerError("Internal server error", status_code=500)
+        assert isinstance(err, VGateError)
+        assert err.status_code == 500
+
+
+class TestConnectionError:
+    def test_basic(self):
+        err = ConnectionError("Cannot connect to server")
+        assert isinstance(err, VGateError)
+        assert err.status_code is None
+
+
+class TestExceptionHierarchy:
+    def test_all_inherit_vgate_error(self):
+        for cls in (AuthenticationError, RateLimitError, ServerError, ConnectionError):
+            assert issubclass(cls, VGateError)
+
+    def test_catchable_as_base(self):
+        try:
+            raise AuthenticationError("test", status_code=401)
+        except VGateError as e:
+            assert e.status_code == 401

--- a/vgate-client/tests/test_models.py
+++ b/vgate-client/tests/test_models.py
@@ -1,0 +1,103 @@
+"""Tests for request/response models."""
+
+from vgate_client.models import (
+    ChatCompletion,
+    ChatCompletionRequest,
+    ChatMessage,
+    EmbeddingRequest,
+    EmbeddingResponse,
+    HealthResponse,
+    RateLimitInfo,
+    Usage,
+)
+
+
+class TestChatCompletionRequest:
+    def test_minimal(self):
+        req = ChatCompletionRequest(
+            model="test-model",
+            messages=[ChatMessage(role="user", content="Hi")],
+        )
+        assert req.model == "test-model"
+        assert req.temperature == 0.7
+        assert req.top_p == 0.9
+        assert req.max_tokens == 256
+
+    def test_custom_params(self):
+        req = ChatCompletionRequest(
+            model="m",
+            messages=[ChatMessage(role="user", content="Hello")],
+            temperature=0.2,
+            top_p=0.5,
+            max_tokens=100,
+        )
+        assert req.temperature == 0.2
+        assert req.top_p == 0.5
+        assert req.max_tokens == 100
+
+    def test_serialization(self):
+        req = ChatCompletionRequest(
+            model="m",
+            messages=[ChatMessage(role="user", content="Hi")],
+        )
+        data = req.model_dump()
+        assert data["messages"][0]["role"] == "user"
+        assert data["messages"][0]["content"] == "Hi"
+
+
+class TestChatCompletion:
+    def test_parse(self, chat_response_payload):
+        resp = ChatCompletion.model_validate(chat_response_payload)
+        assert resp.id == "chatcmpl-abc12345"
+        assert resp.object == "chat.completion"
+        assert resp.choices[0].message.content == "Hello! How can I help you?"
+        assert resp.usage.total_tokens == 18
+
+    def test_defaults(self):
+        resp = ChatCompletion(
+            id="x", created=0, model="m",
+            choices=[],
+        )
+        assert resp.usage.prompt_tokens == 0
+
+
+class TestEmbeddingResponse:
+    def test_parse(self, embedding_response_payload):
+        resp = EmbeddingResponse.model_validate(embedding_response_payload)
+        assert resp.object == "list"
+        assert len(resp.data) == 1
+        assert len(resp.data[0].embedding) == 1536
+
+
+class TestEmbeddingRequest:
+    def test_basic(self):
+        req = EmbeddingRequest(model="m", input="hello world")
+        assert req.input == "hello world"
+
+
+class TestHealthResponse:
+    def test_parse(self, health_response_payload):
+        resp = HealthResponse.model_validate(health_response_payload)
+        assert resp.status == "ok"
+        assert resp.version == "0.3.2"
+
+
+class TestRateLimitInfo:
+    def test_defaults(self):
+        info = RateLimitInfo()
+        assert info.limit is None
+        assert info.remaining is None
+        assert info.retry_after is None
+
+    def test_with_values(self):
+        info = RateLimitInfo(limit=100, remaining=42, reset=1700000000.0, retry_after=5.0)
+        assert info.limit == 100
+        assert info.remaining == 42
+
+
+class TestUsage:
+    def test_defaults(self):
+        u = Usage()
+        assert u.prompt_tokens == 0
+        assert u.completion_tokens == 0
+        assert u.total_tokens == 0

--- a/vgate-client/vgate_client/__init__.py
+++ b/vgate-client/vgate_client/__init__.py
@@ -1,0 +1,66 @@
+"""V-Gate Python Client SDK.
+
+Usage::
+
+    from vgate_client import VGate, AsyncVGate
+
+    # Synchronous
+    client = VGate(base_url="http://localhost:8000", api_key="sk-...")
+    resp = client.chat.create(
+        model="Qwen/Qwen2.5-1.5B-Instruct-AWQ",
+        messages=[{"role": "user", "content": "Hello!"}],
+    )
+    print(resp.choices[0].message.content)
+    client.close()
+
+    # Asynchronous
+    async with AsyncVGate(base_url="http://localhost:8000", api_key="sk-...") as client:
+        resp = await client.chat.create(
+            model="Qwen/Qwen2.5-1.5B-Instruct-AWQ",
+            messages=[{"role": "user", "content": "Hello!"}],
+        )
+"""
+
+from .client import AsyncVGate, VGate
+from .exceptions import (
+    AuthenticationError,
+    ConnectionError,
+    RateLimitError,
+    ServerError,
+    VGateError,
+)
+from .models import (
+    ChatCompletion,
+    ChatMessage,
+    Choice,
+    EmbeddingData,
+    EmbeddingResponse,
+    HealthResponse,
+    RateLimitInfo,
+    ResponseMessage,
+    Usage,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    # Clients
+    "VGate",
+    "AsyncVGate",
+    # Response models
+    "ChatCompletion",
+    "Choice",
+    "ResponseMessage",
+    "EmbeddingResponse",
+    "EmbeddingData",
+    "HealthResponse",
+    "Usage",
+    "RateLimitInfo",
+    "ChatMessage",
+    # Exceptions
+    "VGateError",
+    "AuthenticationError",
+    "RateLimitError",
+    "ServerError",
+    "ConnectionError",
+]

--- a/vgate-client/vgate_client/client.py
+++ b/vgate-client/vgate_client/client.py
@@ -1,0 +1,395 @@
+"""Synchronous and asynchronous clients for the V-Gate API."""
+
+from __future__ import annotations
+
+import time
+from typing import Optional, Union
+
+import httpx
+
+from .exceptions import (
+    AuthenticationError,
+    ConnectionError,
+    RateLimitError,
+    ServerError,
+    VGateError,
+)
+from .models import (
+    ChatCompletion,
+    ChatCompletionRequest,
+    ChatMessage,
+    EmbeddingRequest,
+    EmbeddingResponse,
+    HealthResponse,
+    RateLimitInfo,
+)
+
+_DEFAULT_BASE_URL = "http://localhost:8000"
+_DEFAULT_TIMEOUT = 60.0
+_DEFAULT_MAX_RETRIES = 2
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _parse_rate_limit(headers: httpx.Headers) -> RateLimitInfo:
+    """Extract rate-limit metadata from response headers."""
+    def _int(key: str) -> Optional[int]:
+        v = headers.get(key)
+        return int(v) if v is not None else None
+
+    def _float(key: str) -> Optional[float]:
+        v = headers.get(key)
+        return float(v) if v is not None else None
+
+    return RateLimitInfo(
+        limit=_int("X-RateLimit-Limit"),
+        remaining=_int("X-RateLimit-Remaining"),
+        reset=_float("X-RateLimit-Reset"),
+        retry_after=_float("Retry-After"),
+    )
+
+
+def _raise_for_status(response: httpx.Response) -> None:
+    """Translate HTTP error responses into typed exceptions."""
+    if response.is_success:
+        return
+
+    status = response.status_code
+    try:
+        body = response.json()
+    except Exception:
+        body = {"detail": response.text}
+
+    detail = body.get("detail", response.text)
+
+    if status == 401:
+        raise AuthenticationError(detail, status_code=status, body=body)
+    if status == 429:
+        retry_after = _parse_rate_limit(response.headers).retry_after
+        raise RateLimitError(
+            detail, retry_after=retry_after, status_code=status, body=body,
+        )
+    if status >= 500:
+        raise ServerError(detail, status_code=status, body=body)
+    raise VGateError(detail, status_code=status, body=body)
+
+
+def _build_headers(api_key: Optional[str]) -> dict[str, str]:
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+# ── Resource helpers (namespace objects) ────────────────────────────────────
+
+
+class _SyncChat:
+    """Synchronous chat completions resource — accessed as ``client.chat``."""
+
+    def __init__(self, client: VGate):
+        self._client = client
+
+    def create(
+        self,
+        *,
+        model: str,
+        messages: list[dict[str, str]],
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        max_tokens: int = 256,
+    ) -> ChatCompletion:
+        """Create a chat completion.
+
+        Args:
+            model: Model identifier on the V-Gate server.
+            messages: List of ``{"role": ..., "content": ...}`` dicts.
+            temperature: Sampling temperature.
+            top_p: Top-p nucleus sampling.
+            max_tokens: Maximum tokens to generate.
+
+        Returns:
+            A ``ChatCompletion`` object.
+        """
+        req = ChatCompletionRequest(
+            model=model,
+            messages=[ChatMessage(**m) for m in messages],
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+        )
+        data = self._client._request("POST", "/v1/chat/completions", json=req.model_dump())
+        return ChatCompletion.model_validate(data)
+
+
+class _SyncEmbeddings:
+    """Synchronous embeddings resource — accessed as ``client.embeddings``."""
+
+    def __init__(self, client: VGate):
+        self._client = client
+
+    def create(
+        self,
+        *,
+        model: str,
+        input: str,
+    ) -> EmbeddingResponse:
+        """Create an embedding.
+
+        Args:
+            model: Model identifier.
+            input: Text to embed.
+
+        Returns:
+            An ``EmbeddingResponse`` object.
+        """
+        req = EmbeddingRequest(model=model, input=input)
+        data = self._client._request("POST", "/v1/embeddings", json=req.model_dump())
+        return EmbeddingResponse.model_validate(data)
+
+
+class _AsyncChat:
+    """Async chat completions resource — accessed as ``client.chat``."""
+
+    def __init__(self, client: AsyncVGate):
+        self._client = client
+
+    async def create(
+        self,
+        *,
+        model: str,
+        messages: list[dict[str, str]],
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        max_tokens: int = 256,
+    ) -> ChatCompletion:
+        req = ChatCompletionRequest(
+            model=model,
+            messages=[ChatMessage(**m) for m in messages],
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+        )
+        data = await self._client._request("POST", "/v1/chat/completions", json=req.model_dump())
+        return ChatCompletion.model_validate(data)
+
+
+class _AsyncEmbeddings:
+    """Async embeddings resource — accessed as ``client.embeddings``."""
+
+    def __init__(self, client: AsyncVGate):
+        self._client = client
+
+    async def create(
+        self,
+        *,
+        model: str,
+        input: str,
+    ) -> EmbeddingResponse:
+        req = EmbeddingRequest(model=model, input=input)
+        data = await self._client._request("POST", "/v1/embeddings", json=req.model_dump())
+        return EmbeddingResponse.model_validate(data)
+
+
+# ── Synchronous client ──────────────────────────────────────────────────────
+
+
+class VGate:
+    """Synchronous V-Gate client.
+
+    Example::
+
+        client = VGate(base_url="http://localhost:8000", api_key="sk-...")
+        resp = client.chat.create(
+            model="Qwen/Qwen2.5-1.5B-Instruct-AWQ",
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+        print(resp.choices[0].message.content)
+        client.close()
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str = _DEFAULT_BASE_URL,
+        api_key: Optional[str] = None,
+        timeout: float = _DEFAULT_TIMEOUT,
+        max_retries: int = _DEFAULT_MAX_RETRIES,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.max_retries = max_retries
+        self._http = httpx.Client(
+            base_url=self.base_url,
+            headers=_build_headers(api_key),
+            timeout=timeout,
+        )
+        self.chat = _SyncChat(self)
+        self.embeddings = _SyncEmbeddings(self)
+
+    # -- low-level --------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        **kwargs,
+    ) -> dict:
+        """Send an HTTP request with retry logic for 429 / 5xx."""
+        last_exc: Optional[Exception] = None
+        for attempt in range(1 + self.max_retries):
+            try:
+                response = self._http.request(method, path, **kwargs)
+            except httpx.ConnectError as exc:
+                raise ConnectionError(f"Cannot connect to {self.base_url}: {exc}") from exc
+
+            if response.is_success:
+                return response.json()
+
+            # Decide whether to retry
+            if response.status_code == 429:
+                info = _parse_rate_limit(response.headers)
+                wait = info.retry_after or (2 ** attempt)
+                if attempt < self.max_retries:
+                    time.sleep(wait)
+                    continue
+                _raise_for_status(response)  # exhausted retries
+
+            if response.status_code >= 500 and attempt < self.max_retries:
+                time.sleep(2 ** attempt)
+                continue
+
+            _raise_for_status(response)
+
+        # Should not reach here, but just in case
+        raise last_exc or VGateError("Request failed after retries")
+
+    # -- convenience endpoints --------------------------------------------
+
+    def health(self) -> HealthResponse:
+        """Check server health (``GET /health``)."""
+        try:
+            resp = self._http.get("/health")
+        except httpx.ConnectError as exc:
+            raise ConnectionError(f"Cannot connect to {self.base_url}: {exc}") from exc
+        _raise_for_status(resp)
+        return HealthResponse.model_validate(resp.json())
+
+    def stats(self) -> dict:
+        """Get server statistics (``GET /stats``)."""
+        data = self._request("GET", "/stats")
+        return data
+
+    def rate_limit_info(self, response_headers: dict) -> RateLimitInfo:
+        """Parse rate-limit headers from any raw response headers dict."""
+        return _parse_rate_limit(httpx.Headers(response_headers))
+
+    # -- lifecycle --------------------------------------------------------
+
+    def close(self) -> None:
+        self._http.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+# ── Asynchronous client ─────────────────────────────────────────────────────
+
+
+class AsyncVGate:
+    """Asynchronous V-Gate client.
+
+    Example::
+
+        async with AsyncVGate(base_url="http://localhost:8000", api_key="sk-...") as client:
+            resp = await client.chat.create(
+                model="Qwen/Qwen2.5-1.5B-Instruct-AWQ",
+                messages=[{"role": "user", "content": "Hi"}],
+            )
+            print(resp.choices[0].message.content)
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str = _DEFAULT_BASE_URL,
+        api_key: Optional[str] = None,
+        timeout: float = _DEFAULT_TIMEOUT,
+        max_retries: int = _DEFAULT_MAX_RETRIES,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.max_retries = max_retries
+        self._http = httpx.AsyncClient(
+            base_url=self.base_url,
+            headers=_build_headers(api_key),
+            timeout=timeout,
+        )
+        self.chat = _AsyncChat(self)
+        self.embeddings = _AsyncEmbeddings(self)
+
+    # -- low-level --------------------------------------------------------
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        **kwargs,
+    ) -> dict:
+        """Send an HTTP request with retry logic for 429 / 5xx."""
+        import asyncio
+
+        for attempt in range(1 + self.max_retries):
+            try:
+                response = await self._http.request(method, path, **kwargs)
+            except httpx.ConnectError as exc:
+                raise ConnectionError(f"Cannot connect to {self.base_url}: {exc}") from exc
+
+            if response.is_success:
+                return response.json()
+
+            if response.status_code == 429:
+                info = _parse_rate_limit(response.headers)
+                wait = info.retry_after or (2 ** attempt)
+                if attempt < self.max_retries:
+                    await asyncio.sleep(wait)
+                    continue
+                _raise_for_status(response)
+
+            if response.status_code >= 500 and attempt < self.max_retries:
+                await asyncio.sleep(2 ** attempt)
+                continue
+
+            _raise_for_status(response)
+
+        raise VGateError("Request failed after retries")
+
+    # -- convenience endpoints --------------------------------------------
+
+    async def health(self) -> HealthResponse:
+        """Check server health (``GET /health``)."""
+        try:
+            resp = await self._http.get("/health")
+        except httpx.ConnectError as exc:
+            raise ConnectionError(f"Cannot connect to {self.base_url}: {exc}") from exc
+        _raise_for_status(resp)
+        return HealthResponse.model_validate(resp.json())
+
+    async def stats(self) -> dict:
+        """Get server statistics (``GET /stats``)."""
+        return await self._request("GET", "/stats")
+
+    # -- lifecycle --------------------------------------------------------
+
+    async def close(self) -> None:
+        await self._http.aclose()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        await self.close()

--- a/vgate-client/vgate_client/exceptions.py
+++ b/vgate-client/vgate_client/exceptions.py
@@ -1,0 +1,48 @@
+"""Exception classes for the V-Gate client SDK."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+class VGateError(Exception):
+    """Base exception for all V-Gate client errors."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: Optional[int] = None,
+        body: Optional[dict] = None,
+    ):
+        self.status_code = status_code
+        self.body = body
+        super().__init__(message)
+
+
+class AuthenticationError(VGateError):
+    """Raised when authentication fails (HTTP 401)."""
+
+
+class RateLimitError(VGateError):
+    """Raised when rate limit is exceeded (HTTP 429).
+
+    Attributes:
+        retry_after: Seconds to wait before retrying.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        retry_after: Optional[float] = None,
+        **kwargs,
+    ):
+        self.retry_after = retry_after
+        super().__init__(message, **kwargs)
+
+
+class ServerError(VGateError):
+    """Raised on server-side errors (HTTP 5xx)."""
+
+
+class ConnectionError(VGateError):
+    """Raised when the client cannot connect to the V-Gate server."""

--- a/vgate-client/vgate_client/models.py
+++ b/vgate-client/vgate_client/models.py
@@ -1,0 +1,83 @@
+"""Request and response models for V-Gate API, compatible with OpenAI format."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+# ── Request Models ──────────────────────────────────────────────────────────
+
+
+class ChatMessage(BaseModel):
+    role: str
+    content: str
+
+
+class ChatCompletionRequest(BaseModel):
+    model: str
+    messages: list[ChatMessage]
+    temperature: float = 0.7
+    top_p: float = 0.9
+    max_tokens: int = 256
+
+
+class EmbeddingRequest(BaseModel):
+    model: str
+    input: str
+
+
+# ── Response Models ─────────────────────────────────────────────────────────
+
+
+class Usage(BaseModel):
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+
+class ResponseMessage(BaseModel):
+    role: str
+    content: str
+
+
+class Choice(BaseModel):
+    index: int
+    message: ResponseMessage
+    finish_reason: Optional[str] = None
+
+
+class ChatCompletion(BaseModel):
+    id: str
+    object: str = "chat.completion"
+    created: int
+    model: str
+    choices: list[Choice]
+    usage: Usage = Field(default_factory=Usage)
+
+
+class EmbeddingData(BaseModel):
+    object: str = "embedding"
+    embedding: list[float]
+    index: int
+
+
+class EmbeddingResponse(BaseModel):
+    object: str = "list"
+    data: list[EmbeddingData]
+    model: str
+    usage: Usage = Field(default_factory=Usage)
+
+
+class HealthResponse(BaseModel):
+    status: str
+    version: str
+
+
+class RateLimitInfo(BaseModel):
+    """Rate limit information extracted from response headers."""
+    limit: Optional[int] = None
+    remaining: Optional[int] = None
+    reset: Optional[float] = None
+    retry_after: Optional[float] = None


### PR DESCRIPTION
## Summary

- Add `vgate-client` Python package with sync (`VGate`) and async (`AsyncVGate`) clients
- Typed Pydantic request/response models matching OpenAI-compatible server API
- Automatic retry with exponential backoff on 429 (rate limit) and 5xx (server error)
- Rate-limit header parsing (`X-RateLimit-*`, `Retry-After`)
- Typed exception hierarchy: `AuthenticationError`, `RateLimitError`, `ServerError`, `ConnectionError`
- Context manager support (`with VGate() as client:` / `async with AsyncVGate()`)
- 48 tests covering sync/async clients, models, and exceptions

## Test plan

- [x] 48/48 SDK tests pass (`pytest vgate-client/tests/ -v`)
- [x] 97/97 existing server tests still pass (`pytest tests/ -v`)
- [ ] Manual integration test against running V-Gate server