### PR TITLE
feat: Kubernetes deployment with Kustomize (Phase 4.3)

### DIFF
--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vgate-config
+  labels:
+    app.kubernetes.io/name: vgate
+    app.kubernetes.io/component: config
+data:
+  config.yaml: |
+    version: "0.3.2"
+
+    # Server settings
+    server:
+      host: "0.0.0.0"
+      port: 8000
+
+    # Model configuration
+    model:
+      model_id: "Qwen/Qwen2.5-1.5B-Instruct-AWQ"
+      quantization: "awq"
+      gpu_memory_utilization: 0.7
+      max_model_len: 2048
+      trust_remote_code: true
+      enforce_eager: true
+
+    # Request batching
+    batch:
+      max_batch_size: 8
+      max_wait_time_ms: 50.0
+
+    # Result cache
+    cache:
+      enabled: true
+      maxsize: 1000
+
+    # Default inference parameters
+    inference:
+      temperature: 0.7
+      top_p: 0.9
+      max_tokens: 256
+
+    # Logging configuration
+    logging:
+      level: "INFO"
+      json_format: true
+
+    # Prometheus metrics
+    metrics:
+      enabled: true
+
+    # Security & Access Control
+    security:
+      enabled: true
+      api_keys:
+        - key: "PLACEHOLDER_REPLACE_WITH_REAL_KEY"
+          name: "default"
+          rate_limit: 100
+      rate_limiting:
+        enabled: true
+        default_limit: 60
+        window_seconds: 60
+      exempt_paths:
+        - "/health"
+        - "/metrics"

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vgate
+  labels:
+    app.kubernetes.io/name: vgate
+    app.kubernetes.io/component: gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vgate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vgate
+        app.kubernetes.io/component: gateway
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+        prometheus.io/path: "/metrics"
+    spec:
+      containers:
+        - name: vgate
+          image: vgate:cpu
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          env:
+            - name: VGATE_DRY_RUN
+              value: "true"
+            - name: VGATE_CONFIG_PATH
+              value: "/app/config.yaml"
+            - name: HF_HOME
+              value: "/cache/huggingface"
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: vgate-secrets
+                  key: hf-token
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /app/config.yaml
+              subPath: config.yaml
+              readOnly: true
+            - name: model-cache
+              mountPath: /cache/huggingface
+      volumes:
+        - name: config
+          configMap:
+            name: vgate-config
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: vgate-model-cache

--- a/k8s/base/hpa.yaml
+++ b/k8s/base/hpa.yaml
@@ -1,0 +1,34 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: vgate
+  labels:
+    app.kubernetes.io/name: vgate
+    app.kubernetes.io/component: autoscaler
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: vgate
+  minReplicas: 1
+  maxReplicas: 4
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: vgate
+
+commonLabels:
+  app.kubernetes.io/managed-by: kustomize
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - secret.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - hpa.yaml
+  # Uncomment if Prometheus Operator CRDs are installed:
+  # - servicemonitor.yaml

--- a/k8s/base/namespace.yaml
+++ b/k8s/base/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vgate
+  labels:
+    app.kubernetes.io/name: vgate
+    app.kubernetes.io/part-of: vgate

--- a/k8s/base/pvc.yaml
+++ b/k8s/base/pvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vgate-model-cache
+  labels:
+    app.kubernetes.io/name: vgate
+    app.kubernetes.io/component: storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  # For multi-replica GPU deployments, consider upgrading to:
+  #   - ReadWriteMany with an NFS-based StorageClass
+  #   - A shared model cache layer (e.g., S3 + init container)

--- a/k8s/base/secret.yaml
+++ b/k8s/base/secret.yaml
@@ -1,0 +1,18 @@
+# WARNING: This file contains placeholder secrets for development/demo only.
+# In production, use one of the following:
+#   - External Secrets Operator (https://external-secrets.io)
+#   - Sealed Secrets (https://sealed-secrets.netlify.app)
+#   - Cloud provider secret managers (AWS Secrets Manager, GCP Secret Manager, etc.)
+#
+# NEVER commit real credentials to version control.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vgate-secrets
+  labels:
+    app.kubernetes.io/name: vgate
+    app.kubernetes.io/component: secrets
+type: Opaque
+stringData:
+  api-key: "sk-vgate-dev-example"
+  hf-token: "hf_PLACEHOLDER_REPLACE_WITH_REAL_TOKEN"

--- a/k8s/base/service.yaml
+++ b/k8s/base/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vgate
+  labels:
+    app.kubernetes.io/name: vgate
+    app.kubernetes.io/component: gateway
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: vgate

--- a/k8s/base/servicemonitor.yaml
+++ b/k8s/base/servicemonitor.yaml
@@ -1,0 +1,18 @@
+# ServiceMonitor for Prometheus Operator integration.
+# Requires the Prometheus Operator CRDs to be installed in the cluster.
+# This resource is commented out in kustomization.yaml by default.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: vgate
+  labels:
+    app.kubernetes.io/name: vgate
+    app.kubernetes.io/component: monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vgate
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 15s

--- a/k8s/overlays/cpu/deployment-patch.yaml
+++ b/k8s/overlays/cpu/deployment-patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vgate
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: vgate
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 10
+            periodSeconds: 3

--- a/k8s/overlays/cpu/kustomization.yaml
+++ b/k8s/overlays/cpu/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - path: deployment-patch.yaml

--- a/k8s/overlays/gpu/deployment-patch.yaml
+++ b/k8s/overlays/gpu/deployment-patch.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vgate
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: vgate
+          image: vgate:latest
+          env:
+            - name: VGATE_DRY_RUN
+              value: "false"
+            - name: VGATE_CONFIG_PATH
+              value: "/app/config.yaml"
+            - name: HF_HOME
+              value: "/cache/huggingface"
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: vgate-secrets
+                  key: hf-token
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: "all"
+          resources:
+            requests:
+              cpu: "2"
+              memory: 8Gi
+              nvidia.com/gpu: "1"
+            limits:
+              cpu: "4"
+              memory: 16Gi
+              nvidia.com/gpu: "1"
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule

--- a/k8s/overlays/gpu/hpa-patch.yaml
+++ b/k8s/overlays/gpu/hpa-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: vgate
+spec:
+  maxReplicas: 2
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/k8s/overlays/gpu/kustomization.yaml
+++ b/k8s/overlays/gpu/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - path: deployment-patch.yaml
+  - path: hpa-patch.yaml


### PR DESCRIPTION
## Summary

- Add Kustomize-based Kubernetes manifests with base/overlays pattern for GPU and CPU deployment modes
- Implement HorizontalPodAutoscaler with CPU-based autoscaling (1–4 replicas) and conservative scale-down policies
- Include full health probe configuration (startup/readiness/liveness), Prometheus annotations, ConfigMap/Secret/PVC resources

## Architecture

```
k8s/
├── base/           # Shared resources (CPU/dry-run defaults)
│   ├── namespace, configmap, secret, deployment, service
│   ├── hpa, pvc, servicemonitor (optional)
│   └── kustomization.yaml
└── overlays/
    ├── gpu/        # Production: NVIDIA GPU scheduling, tolerations, max 2 replicas
    └── cpu/        # Testing: lightweight dry-run, 2 replicas, fast startup
```

## Quick Start

```bash
# CPU mode (testing/demo)
kubectl apply -k k8s/overlays/cpu/

# GPU mode (production)
kubectl apply -k k8s/overlays/gpu/

# Verify
kubectl get all -n vgate
kubectl get hpa -n vgate --watch
```

## Test plan

- [x] All 14 YAML files pass structural validation
- [x] All kustomization references verified internally consistent
- [x] 97 server tests pass (no regressions)
- [x] 48 SDK tests pass (no regressions)
- [ ] `kubectl apply -k k8s/overlays/cpu/ --dry-run=client` validates against a cluster
- [ ] Port-forward and verify `/health` + `/metrics` endpoints