### PR TITLE
Add concurrent load benchmarking and a real GPU baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,27 @@ PYTHONPATH=. python benchmarks/bench_compare.py --backends vllm sglang --output 
 
 ### Benchmark Current Server Backend
 
-`POST /v1/benchmark` runs benchmark through the full server pipeline (batcher + cache + backend) using the active `model.engine_type`.
+`POST /v1/benchmark` runs benchmark through the full server pipeline (batcher + cache + backend) using the active `model.engine_type`. It reports latency (mean/p50/p95), TTFT/TPOT (mean/p50/p95), batching stats (batches formed, average batch size, deduplication), and cache hit rate for the run.
+
+### Concurrent Load Benchmark
+
+`benchmarks/bench_load.py` drives real concurrent HTTP traffic at a *running* server's `/v1/chat/completions`, then diffs `/stats` before/after to attribute batching and cache behavior to the run:
+
+```bash
+# Start a server first, e.g.: VGATE_DRY_RUN=true python main.py
+PYTHONPATH=. python benchmarks/bench_load.py --concurrency 8 --requests 80
+PYTHONPATH=. python benchmarks/bench_load.py --prompt-file prompts.txt --output json
+```
+
+`benchmarks/run_report.py` orchestrates a full report: it spawns a fresh server subprocess per scenario (dry-run baseline, a batch-size sweep, and a cache/dedup-impact comparison) and writes the results to [`benchmarks/results/baseline.md`](benchmarks/results/baseline.md):
+
+```bash
+PYTHONPATH=. python benchmarks/run_report.py --requests 60 --concurrency 8
+```
+
+[`benchmarks/results/baseline.md`](benchmarks/results/baseline.md) is a **dry-run baseline** (no GPU) — the mock backend uses a synthetic per-call delay (`VGATE_DRYRUN_SIMULATED_LATENCY_MS`) so batching has something real to amortize, but it does not measure actual model throughput.
+
+[`benchmarks/results/vllm_baseline.md`](benchmarks/results/vllm_baseline.md) is a **real GPU baseline**: `Qwen/Qwen2.5-1.5B-Instruct-AWQ` on an RTX 3060 Laptop GPU (6GB VRAM) via vLLM 0.26. Producing it surfaced two real bugs (now fixed): vLLM disables pinned memory by default under WSL2 even on kernels that support it (crashes at startup unless `VLLM_WSL2_ENABLE_PIN_MEMORY=1`), and `VLLMBackend` was reading vLLM metrics fields that had been renamed upstream combined with an `LLM()` default that disables stats collection — so TTFT/TPOT were silently always 0 for the real backend before this fix. See the report for the full data and a known `max_batch_size` batching-cap gap it also surfaced.
 
 ---
 

--- a/benchmarks/_aggregate_results.py
+++ b/benchmarks/_aggregate_results.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Copyright 2025 the V-Gate authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Combine per-scenario JSON files written by _run_scenario_cli.py into a single
+markdown report. Companion to _run_scenario_cli.py's split-into-many-processes
+workflow (used when scenarios are too slow to fit in one process, e.g. a real
+GPU backend where each scenario pays a multi-minute model load).
+
+Usage:
+    python benchmarks/_aggregate_results.py \\
+        --title "V-Gate vLLM Benchmark (RTX 3060 Laptop, real GPU)" \\
+        --notes "Some caveat text..." \\
+        --out benchmarks/results/vllm_baseline.md \\
+        benchmarks/results/vllm/batch_1.json benchmarks/results/vllm/batch_8.json ...
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from benchmarks.bench_load import format_markdown  # noqa: E402
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Aggregate scenario JSON files into a markdown report")
+    parser.add_argument("json_files", nargs="+", help="Scenario JSON files, in report order")
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--notes", default="")
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    lines = [
+        f"# {args.title}",
+        "",
+        f"Generated: {datetime.now(timezone.utc).isoformat()}",
+        "",
+    ]
+    if args.notes:
+        lines += [args.notes, ""]
+
+    for path in args.json_files:
+        result = json.loads(Path(path).read_text(encoding="utf-8"))
+        lines.append(format_markdown(result, title=result.get("title", Path(path).stem)))
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("\n".join(lines), encoding="utf-8")
+    print(f"Wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/_run_scenario_cli.py
+++ b/benchmarks/_run_scenario_cli.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright 2025 the V-Gate authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Run exactly one run_report.py scenario and write its JSON result to disk.
+
+Exists so a real (GPU) benchmark run — where each scenario pays a multi-minute
+model load — can be driven as a sequence of short-lived tool invocations
+instead of one long-running process.
+
+Usage:
+    python benchmarks/_run_scenario_cli.py \\
+        --title "Baseline (max_batch_size=8, all-unique prompts)" \\
+        --batch-size 8 --prompts unique --engine-type vllm \\
+        --concurrency 8 --requests 40 --out benchmarks/results/vllm/baseline.json
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from benchmarks.run_report import (  # noqa: E402
+    REPEATED_PROMPTS,
+    UNIQUE_PROMPTS,
+    _run_scenario,
+)
+
+
+async def _main(args: argparse.Namespace) -> None:
+    prompts = REPEATED_PROMPTS if args.prompts == "repeated" else UNIQUE_PROMPTS
+
+    if args.engine_type == "dry-run":
+        env = {"VGATE_DRY_RUN": "true"}
+        startup_timeout_s = 30.0
+    else:
+        env = {
+            "VGATE_MODEL__ENGINE_TYPE": args.engine_type,
+            "VLLM_WSL2_ENABLE_PIN_MEMORY": "1",
+        }
+        startup_timeout_s = 300.0
+
+    env["VGATE_BATCH__MAX_BATCH_SIZE"] = str(args.batch_size)
+    env["VGATE_BATCH__MAX_WAIT_TIME_MS"] = "50"
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    log_dir = out_path.parent / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    result = await _run_scenario(
+        args.title, env, args.concurrency, args.requests, prompts,
+        startup_timeout_s, log_dir,
+    )
+    out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(f"Wrote {out_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run a single benchmark scenario")
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--batch-size", type=int, required=True)
+    parser.add_argument("--prompts", choices=["unique", "repeated"], required=True)
+    parser.add_argument("--engine-type", default="vllm", choices=["dry-run", "vllm", "sglang"])
+    parser.add_argument("--concurrency", type=int, default=8)
+    parser.add_argument("--requests", type=int, default=40)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+    asyncio.run(_main(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_load.py
+++ b/benchmarks/bench_load.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+# Copyright 2025 the V-Gate authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Concurrent load benchmark against a *running* V-Gate server.
+
+Unlike bench_compare.py (which drives the engine in-process), this tool
+exercises the full HTTP path: security middleware, batcher, cache, and
+backend. It measures client-observed latency percentiles and pulls
+batch/cache/queue counters from /stats to show what the server did with
+the load.
+
+Usage:
+    # Start a server first, e.g.:
+    #   VGATE_DRY_RUN=true python main.py
+    python benchmarks/bench_load.py --concurrency 8 --requests 80
+    python benchmarks/bench_load.py --prompt-file prompts.txt --output json
+"""
+
+import argparse
+import asyncio
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+DEFAULT_PROMPTS = [
+    "Explain the concept of machine learning in one paragraph.",
+    "Write a Python function that computes the Fibonacci sequence.",
+    "What are the benefits of using a load balancer?",
+    "Summarize the CAP theorem in two sentences.",
+]
+
+
+def _percentile(data: List[float], pct: float) -> float:
+    if not data:
+        return 0.0
+    s = sorted(data)
+    idx = min(int(len(s) * pct / 100), len(s) - 1)
+    return s[idx]
+
+
+async def _get_json(session: aiohttp.ClientSession, url: str) -> Dict[str, Any]:
+    async with session.get(url) as resp:
+        return await resp.json()
+
+
+async def _send_one(
+    session: aiohttp.ClientSession,
+    url: str,
+    prompt: str,
+    max_tokens: int,
+    headers: Optional[Dict[str, str]],
+) -> Dict[str, Any]:
+    payload = {
+        "model": "vgate-bench",
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+    }
+    start = time.perf_counter()
+    try:
+        async with session.post(url, json=payload, headers=headers) as resp:
+            body = await resp.json()
+            ok = resp.status == 200 and "choices" in body
+    except Exception:
+        ok = False
+        body = {}
+    latency = time.perf_counter() - start
+    tokens = body.get("usage", {}).get("completion_tokens", 0) if ok else 0
+    return {"latency_s": latency, "ok": ok, "tokens": tokens}
+
+
+async def run_load_test(
+    base_url: str,
+    concurrency: int,
+    total_requests: int,
+    prompts: List[str],
+    max_tokens: int = 64,
+    api_key: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Fire `total_requests` chat completion requests at `concurrency` concurrent
+    workers against a running server, then diff /stats before and after to
+    attribute batching/cache behavior to this run.
+    """
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
+    chat_url = f"{base_url}/v1/chat/completions"
+
+    async with aiohttp.ClientSession() as session:
+        stats_before = await _get_json(session, f"{base_url}/stats")
+
+        sem = asyncio.Semaphore(concurrency)
+
+        async def _bounded(i: int) -> Dict[str, Any]:
+            async with sem:
+                return await _send_one(
+                    session, chat_url, prompts[i % len(prompts)], max_tokens, headers
+                )
+
+        wall_start = time.perf_counter()
+        results = await asyncio.gather(*[_bounded(i) for i in range(total_requests)])
+        wall_time = time.perf_counter() - wall_start
+
+        stats_after = await _get_json(session, f"{base_url}/stats")
+
+    latencies = [r["latency_s"] for r in results if r["ok"]]
+    failures = sum(1 for r in results if not r["ok"])
+    total_tokens = sum(r["tokens"] for r in results)
+
+    before_b, after_b = stats_before["batcher"], stats_after["batcher"]
+    before_c, after_c = stats_before["cache"], stats_after["cache"]
+
+    new_requests = after_b["total_requests"] - before_b["total_requests"]
+    new_batches = after_b["total_batches"] - before_b["total_batches"]
+    new_dedup = after_b["total_deduplicated"] - before_b["total_deduplicated"]
+    new_hits = after_c["hits"] - before_c["hits"]
+    new_misses = after_c["misses"] - before_c["misses"]
+
+    return {
+        "config": {
+            "concurrency": concurrency,
+            "total_requests": total_requests,
+            "unique_prompts": len(prompts),
+            "max_tokens": max_tokens,
+        },
+        "wall_time_s": round(wall_time, 4),
+        "failures": failures,
+        "latency": {
+            "mean_s": round(statistics.mean(latencies), 4) if latencies else 0,
+            "p50_s": round(_percentile(latencies, 50), 4),
+            "p95_s": round(_percentile(latencies, 95), 4),
+            "p99_s": round(_percentile(latencies, 99), 4),
+            "max_s": round(max(latencies), 4) if latencies else 0,
+        },
+        "throughput": {
+            "total_tokens": total_tokens,
+            "tokens_per_second": round(total_tokens / wall_time, 2) if wall_time > 0 else 0,
+            "requests_per_second": round(total_requests / wall_time, 2) if wall_time > 0 else 0,
+        },
+        "batching": {
+            "requests": new_requests,
+            "batches": new_batches,
+            "average_batch_size": round(new_requests / new_batches, 2) if new_batches > 0 else 0,
+            "deduplicated": new_dedup,
+            "avg_queue_time_s": after_b.get("avg_queue_time_s", 0),
+            "avg_ttft_s": after_b.get("avg_ttft_s", 0),
+            "avg_tpot_s": after_b.get("avg_tpot_s", 0),
+        },
+        "cache": {
+            "hits": new_hits,
+            "misses": new_misses,
+            "hit_rate": (
+                round(new_hits / (new_hits + new_misses), 4)
+                if (new_hits + new_misses) > 0 else 0
+            ),
+        },
+    }
+
+
+def load_prompts(prompt_file: Optional[str]) -> List[str]:
+    if not prompt_file:
+        return DEFAULT_PROMPTS
+    lines = [
+        line.strip()
+        for line in Path(prompt_file).read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    return lines or DEFAULT_PROMPTS
+
+
+def format_markdown(result: Dict[str, Any], title: str = "V-Gate Load Benchmark") -> str:
+    c, lat, thr = result["config"], result["latency"], result["throughput"]
+    b, ch = result["batching"], result["cache"]
+    lines = [
+        f"## {title}",
+        "",
+        f"- Concurrency: {c['concurrency']}",
+        f"- Total requests: {c['total_requests']}",
+        f"- Unique prompts: {c['unique_prompts']}",
+        f"- Max tokens: {c['max_tokens']}",
+        f"- Failures: {result['failures']}",
+        f"- Wall time: {result['wall_time_s']}s",
+        "",
+        "| Metric | Value |",
+        "|---|---|",
+        f"| Latency mean (s) | {lat['mean_s']} |",
+        f"| Latency p50 (s) | {lat['p50_s']} |",
+        f"| Latency p95 (s) | {lat['p95_s']} |",
+        f"| Latency p99 (s) | {lat['p99_s']} |",
+        f"| Latency max (s) | {lat['max_s']} |",
+        f"| Tokens/sec | {thr['tokens_per_second']} |",
+        f"| Requests/sec | {thr['requests_per_second']} |",
+        f"| Avg batch size | {b['average_batch_size']} |",
+        f"| Batches formed | {b['batches']} |",
+        f"| Deduplicated requests | {b['deduplicated']} |",
+        f"| Avg queue time (s) | {b['avg_queue_time_s']} |",
+        f"| Avg TTFT (s) | {b['avg_ttft_s']} |",
+        f"| Avg TPOT (s) | {b['avg_tpot_s']} |",
+        f"| Cache hit rate (this run) | {ch['hit_rate']} |",
+        f"| Cache hits / misses (this run) | {ch['hits']} / {ch['misses']} |",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+async def _main_async(args: argparse.Namespace) -> Dict[str, Any]:
+    prompts = load_prompts(args.prompt_file)
+    return await run_load_test(
+        base_url=args.url,
+        concurrency=args.concurrency,
+        total_requests=args.requests,
+        prompts=prompts,
+        max_tokens=args.max_tokens,
+        api_key=args.api_key,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="V-Gate concurrent load benchmark (hits a running server)"
+    )
+    parser.add_argument("--url", default="http://localhost:8000", help="Base URL of a running V-Gate server")
+    parser.add_argument("--concurrency", type=int, default=8, help="Concurrent in-flight requests")
+    parser.add_argument("--requests", type=int, default=80, help="Total number of requests to send")
+    parser.add_argument("--prompt-file", default=None, help="Path to a text file with one prompt per line")
+    parser.add_argument("--max-tokens", type=int, default=64, help="max_tokens per request")
+    parser.add_argument("--api-key", default=None, help="Bearer API key, if server security is enabled")
+    parser.add_argument(
+        "--stream", action="store_true",
+        help="Not implemented: V-Gate has no SSE streaming yet (see ROADMAP.md Phase 2)",
+    )
+    parser.add_argument("--output", choices=["json", "markdown"], default="markdown")
+    args = parser.parse_args()
+
+    if args.stream:
+        print(
+            "--stream is not supported: V-Gate does not implement SSE streaming yet "
+            "(see ROADMAP.md Phase 2). Re-run without --stream.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    result = asyncio.run(_main_async(args))
+
+    if args.output == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(format_markdown(result, title=f"Load Benchmark: {args.url}"))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/results/baseline.json
+++ b/benchmarks/results/baseline.json
@@ -1,0 +1,254 @@
+[
+  {
+    "config": {
+      "concurrency": 2,
+      "total_requests": 10,
+      "unique_prompts": 64,
+      "max_tokens": 64
+    },
+    "wall_time_s": 0.9369,
+    "failures": 0,
+    "latency": {
+      "mean_s": 0.1873,
+      "p50_s": 0.1938,
+      "p95_s": 0.1953,
+      "p99_s": 0.1953,
+      "max_s": 0.1953
+    },
+    "throughput": {
+      "total_tokens": 80,
+      "tokens_per_second": 85.39,
+      "requests_per_second": 10.67
+    },
+    "batching": {
+      "requests": 10,
+      "batches": 5,
+      "average_batch_size": 2.0,
+      "deduplicated": 0,
+      "avg_queue_time_s": 0.0406,
+      "avg_ttft_s": 0.0,
+      "avg_tpot_s": 0.009
+    },
+    "cache": {
+      "hits": 0,
+      "misses": 10,
+      "hit_rate": 0.0
+    },
+    "title": "Baseline (max_batch_size=8, all-unique prompts)",
+    "env": {
+      "VGATE_DRY_RUN": "true",
+      "VGATE_BATCH__MAX_BATCH_SIZE": "8",
+      "VGATE_BATCH__MAX_WAIT_TIME_MS": "50"
+    }
+  },
+  {
+    "config": {
+      "concurrency": 2,
+      "total_requests": 10,
+      "unique_prompts": 64,
+      "max_tokens": 64
+    },
+    "wall_time_s": 1.4431,
+    "failures": 0,
+    "latency": {
+      "mean_s": 0.2742,
+      "p50_s": 0.288,
+      "p95_s": 0.2911,
+      "p99_s": 0.2911,
+      "max_s": 0.2911
+    },
+    "throughput": {
+      "total_tokens": 80,
+      "tokens_per_second": 55.44,
+      "requests_per_second": 6.93
+    },
+    "batching": {
+      "requests": 10,
+      "batches": 10,
+      "average_batch_size": 1.0,
+      "deduplicated": 0,
+      "avg_queue_time_s": 0.1278,
+      "avg_ttft_s": 0.0,
+      "avg_tpot_s": 0.0179
+    },
+    "cache": {
+      "hits": 0,
+      "misses": 10,
+      "hit_rate": 0.0
+    },
+    "title": "Batch size sweep: max_batch_size=1",
+    "env": {
+      "VGATE_DRY_RUN": "true",
+      "VGATE_BATCH__MAX_BATCH_SIZE": "1",
+      "VGATE_BATCH__MAX_WAIT_TIME_MS": "50"
+    }
+  },
+  {
+    "config": {
+      "concurrency": 2,
+      "total_requests": 10,
+      "unique_prompts": 64,
+      "max_tokens": 64
+    },
+    "wall_time_s": 0.9496,
+    "failures": 0,
+    "latency": {
+      "mean_s": 0.1899,
+      "p50_s": 0.1941,
+      "p95_s": 0.1946,
+      "p99_s": 0.1946,
+      "max_s": 0.1946
+    },
+    "throughput": {
+      "total_tokens": 80,
+      "tokens_per_second": 84.24,
+      "requests_per_second": 10.53
+    },
+    "batching": {
+      "requests": 10,
+      "batches": 5,
+      "average_batch_size": 2.0,
+      "deduplicated": 0,
+      "avg_queue_time_s": 0.043,
+      "avg_ttft_s": 0.0,
+      "avg_tpot_s": 0.0089
+    },
+    "cache": {
+      "hits": 0,
+      "misses": 10,
+      "hit_rate": 0.0
+    },
+    "title": "Batch size sweep: max_batch_size=4",
+    "env": {
+      "VGATE_DRY_RUN": "true",
+      "VGATE_BATCH__MAX_BATCH_SIZE": "4",
+      "VGATE_BATCH__MAX_WAIT_TIME_MS": "50"
+    }
+  },
+  {
+    "config": {
+      "concurrency": 2,
+      "total_requests": 10,
+      "unique_prompts": 64,
+      "max_tokens": 64
+    },
+    "wall_time_s": 0.9298,
+    "failures": 0,
+    "latency": {
+      "mean_s": 0.1858,
+      "p50_s": 0.1941,
+      "p95_s": 0.1958,
+      "p99_s": 0.1958,
+      "max_s": 0.1958
+    },
+    "throughput": {
+      "total_tokens": 80,
+      "tokens_per_second": 86.04,
+      "requests_per_second": 10.76
+    },
+    "batching": {
+      "requests": 10,
+      "batches": 5,
+      "average_batch_size": 2.0,
+      "deduplicated": 0,
+      "avg_queue_time_s": 0.0388,
+      "avg_ttft_s": 0.0,
+      "avg_tpot_s": 0.0089
+    },
+    "cache": {
+      "hits": 0,
+      "misses": 10,
+      "hit_rate": 0.0
+    },
+    "title": "Batch size sweep: max_batch_size=16",
+    "env": {
+      "VGATE_DRY_RUN": "true",
+      "VGATE_BATCH__MAX_BATCH_SIZE": "16",
+      "VGATE_BATCH__MAX_WAIT_TIME_MS": "50"
+    }
+  },
+  {
+    "config": {
+      "concurrency": 2,
+      "total_requests": 10,
+      "unique_prompts": 64,
+      "max_tokens": 64
+    },
+    "wall_time_s": 0.937,
+    "failures": 0,
+    "latency": {
+      "mean_s": 0.1873,
+      "p50_s": 0.1939,
+      "p95_s": 0.1942,
+      "p99_s": 0.1942,
+      "max_s": 0.1942
+    },
+    "throughput": {
+      "total_tokens": 80,
+      "tokens_per_second": 85.38,
+      "requests_per_second": 10.67
+    },
+    "batching": {
+      "requests": 10,
+      "batches": 5,
+      "average_batch_size": 2.0,
+      "deduplicated": 0,
+      "avg_queue_time_s": 0.0406,
+      "avg_ttft_s": 0.0,
+      "avg_tpot_s": 0.009
+    },
+    "cache": {
+      "hits": 0,
+      "misses": 10,
+      "hit_rate": 0.0
+    },
+    "title": "Batch size sweep: max_batch_size=32",
+    "env": {
+      "VGATE_DRY_RUN": "true",
+      "VGATE_BATCH__MAX_BATCH_SIZE": "32",
+      "VGATE_BATCH__MAX_WAIT_TIME_MS": "50"
+    }
+  },
+  {
+    "config": {
+      "concurrency": 2,
+      "total_requests": 10,
+      "unique_prompts": 3,
+      "max_tokens": 64
+    },
+    "wall_time_s": 0.381,
+    "failures": 0,
+    "latency": {
+      "mean_s": 0.0761,
+      "p50_s": 0.002,
+      "p95_s": 0.1944,
+      "p99_s": 0.1944,
+      "max_s": 0.1944
+    },
+    "throughput": {
+      "total_tokens": 80,
+      "tokens_per_second": 209.96,
+      "requests_per_second": 26.24
+    },
+    "batching": {
+      "requests": 4,
+      "batches": 2,
+      "average_batch_size": 2.0,
+      "deduplicated": 1,
+      "avg_queue_time_s": 0.0401,
+      "avg_ttft_s": 0.0,
+      "avg_tpot_s": 0.0119
+    },
+    "cache": {
+      "hits": 6,
+      "misses": 4,
+      "hit_rate": 0.6
+    },
+    "title": "Cache impact: 3 repeated prompts (high reuse) vs. baseline's all-unique prompts",
+    "env": {
+      "VGATE_DRY_RUN": "true",
+      "VGATE_BATCH__MAX_BATCH_SIZE": "8",
+      "VGATE_BATCH__MAX_WAIT_TIME_MS": "50"
+    }
+  }
+]

--- a/benchmarks/results/baseline.md
+++ b/benchmarks/results/baseline.md
@@ -1,0 +1,169 @@
+# V-Gate Benchmark Report
+
+Generated: 2026-07-30T06:36:26.561474+00:00
+Engine: dry-run
+Concurrency: 2, requests per scenario: 10
+
+> **Dry-run baseline.** No GPU/model is used; the backend is a mock that echoes a fixed response after a synthetic delay of `15ms + 2ms * max_tokens` per batch call (see `VGATE_DRYRUN_SIMULATED_LATENCY_MS` in `vgate/backends/base.py`). This isolates the batcher/cache/HTTP-layer behavior from real inference cost and is **not** a GPU throughput measurement. A vLLM/SGLang single-worker baseline on real hardware is still needed (`--engine-type vllm|sglang`) before quoting real tokens/sec numbers.
+
+## Baseline (max_batch_size=8, all-unique prompts)
+
+- Concurrency: 2
+- Total requests: 10
+- Unique prompts: 64
+- Max tokens: 64
+- Failures: 0
+- Wall time: 0.9369s
+
+| Metric | Value |
+|---|---|
+| Latency mean (s) | 0.1873 |
+| Latency p50 (s) | 0.1938 |
+| Latency p95 (s) | 0.1953 |
+| Latency p99 (s) | 0.1953 |
+| Latency max (s) | 0.1953 |
+| Tokens/sec | 85.39 |
+| Requests/sec | 10.67 |
+| Avg batch size | 2.0 |
+| Batches formed | 5 |
+| Deduplicated requests | 0 |
+| Avg queue time (s) | 0.0406 |
+| Avg TTFT (s) | 0.0 |
+| Avg TPOT (s) | 0.009 |
+| Cache hit rate (this run) | 0.0 |
+| Cache hits / misses (this run) | 0 / 10 |
+
+## Batch size sweep: max_batch_size=1
+
+- Concurrency: 2
+- Total requests: 10
+- Unique prompts: 64
+- Max tokens: 64
+- Failures: 0
+- Wall time: 1.4431s
+
+| Metric | Value |
+|---|---|
+| Latency mean (s) | 0.2742 |
+| Latency p50 (s) | 0.288 |
+| Latency p95 (s) | 0.2911 |
+| Latency p99 (s) | 0.2911 |
+| Latency max (s) | 0.2911 |
+| Tokens/sec | 55.44 |
+| Requests/sec | 6.93 |
+| Avg batch size | 1.0 |
+| Batches formed | 10 |
+| Deduplicated requests | 0 |
+| Avg queue time (s) | 0.1278 |
+| Avg TTFT (s) | 0.0 |
+| Avg TPOT (s) | 0.0179 |
+| Cache hit rate (this run) | 0.0 |
+| Cache hits / misses (this run) | 0 / 10 |
+
+## Batch size sweep: max_batch_size=4
+
+- Concurrency: 2
+- Total requests: 10
+- Unique prompts: 64
+- Max tokens: 64
+- Failures: 0
+- Wall time: 0.9496s
+
+| Metric | Value |
+|---|---|
+| Latency mean (s) | 0.1899 |
+| Latency p50 (s) | 0.1941 |
+| Latency p95 (s) | 0.1946 |
+| Latency p99 (s) | 0.1946 |
+| Latency max (s) | 0.1946 |
+| Tokens/sec | 84.24 |
+| Requests/sec | 10.53 |
+| Avg batch size | 2.0 |
+| Batches formed | 5 |
+| Deduplicated requests | 0 |
+| Avg queue time (s) | 0.043 |
+| Avg TTFT (s) | 0.0 |
+| Avg TPOT (s) | 0.0089 |
+| Cache hit rate (this run) | 0.0 |
+| Cache hits / misses (this run) | 0 / 10 |
+
+## Batch size sweep: max_batch_size=16
+
+- Concurrency: 2
+- Total requests: 10
+- Unique prompts: 64
+- Max tokens: 64
+- Failures: 0
+- Wall time: 0.9298s
+
+| Metric | Value |
+|---|---|
+| Latency mean (s) | 0.1858 |
+| Latency p50 (s) | 0.1941 |
+| Latency p95 (s) | 0.1958 |
+| Latency p99 (s) | 0.1958 |
+| Latency max (s) | 0.1958 |
+| Tokens/sec | 86.04 |
+| Requests/sec | 10.76 |
+| Avg batch size | 2.0 |
+| Batches formed | 5 |
+| Deduplicated requests | 0 |
+| Avg queue time (s) | 0.0388 |
+| Avg TTFT (s) | 0.0 |
+| Avg TPOT (s) | 0.0089 |
+| Cache hit rate (this run) | 0.0 |
+| Cache hits / misses (this run) | 0 / 10 |
+
+## Batch size sweep: max_batch_size=32
+
+- Concurrency: 2
+- Total requests: 10
+- Unique prompts: 64
+- Max tokens: 64
+- Failures: 0
+- Wall time: 0.937s
+
+| Metric | Value |
+|---|---|
+| Latency mean (s) | 0.1873 |
+| Latency p50 (s) | 0.1939 |
+| Latency p95 (s) | 0.1942 |
+| Latency p99 (s) | 0.1942 |
+| Latency max (s) | 0.1942 |
+| Tokens/sec | 85.38 |
+| Requests/sec | 10.67 |
+| Avg batch size | 2.0 |
+| Batches formed | 5 |
+| Deduplicated requests | 0 |
+| Avg queue time (s) | 0.0406 |
+| Avg TTFT (s) | 0.0 |
+| Avg TPOT (s) | 0.009 |
+| Cache hit rate (this run) | 0.0 |
+| Cache hits / misses (this run) | 0 / 10 |
+
+## Cache impact: 3 repeated prompts (high reuse) vs. baseline's all-unique prompts
+
+- Concurrency: 2
+- Total requests: 10
+- Unique prompts: 3
+- Max tokens: 64
+- Failures: 0
+- Wall time: 0.381s
+
+| Metric | Value |
+|---|---|
+| Latency mean (s) | 0.0761 |
+| Latency p50 (s) | 0.002 |
+| Latency p95 (s) | 0.1944 |
+| Latency p99 (s) | 0.1944 |
+| Latency max (s) | 0.1944 |
+| Tokens/sec | 209.96 |
+| Requests/sec | 26.24 |
+| Avg batch size | 2.0 |
+| Batches formed | 2 |
+| Deduplicated requests | 1 |
+| Avg queue time (s) | 0.0401 |
+| Avg TTFT (s) | 0.0 |
+| Avg TPOT (s) | 0.0119 |
+| Cache hit rate (this run) | 0.6 |
+| Cache hits / misses (this run) | 6 / 4 |

--- a/benchmarks/results/vllm/batch_1.json
+++ b/benchmarks/results/vllm/batch_1.json
@@ -1,0 +1,43 @@
+{
+  "config": {
+    "concurrency": 8,
+    "total_requests": 24,
+    "unique_prompts": 64,
+    "max_tokens": 64
+  },
+  "wall_time_s": 6.3054,
+  "failures": 0,
+  "latency": {
+    "mean_s": 2.055,
+    "p50_s": 2.1717,
+    "p95_s": 2.6624,
+    "p99_s": 2.6626,
+    "max_s": 2.6626
+  },
+  "throughput": {
+    "total_tokens": 1079,
+    "tokens_per_second": 171.12,
+    "requests_per_second": 3.81
+  },
+  "batching": {
+    "requests": 24,
+    "batches": 6,
+    "average_batch_size": 4.0,
+    "deduplicated": 0,
+    "avg_queue_time_s": 0.9553,
+    "avg_ttft_s": 0.0506,
+    "avg_tpot_s": 0.0164
+  },
+  "cache": {
+    "hits": 0,
+    "misses": 24,
+    "hit_rate": 0.0
+  },
+  "title": "Batch size sweep: max_batch_size=1",
+  "env": {
+    "VGATE_MODEL__ENGINE_TYPE": "vllm",
+    "VLLM_WSL2_ENABLE_PIN_MEMORY": "1",
+    "VGATE_BATCH__MAX_BATCH_SIZE": "1",
+    "VGATE_BATCH__MAX_WAIT_TIME_MS": "50"
+  }
+}

--- a/benchmarks/results/vllm/batch_32.json
+++ b/benchmarks/results/vllm/batch_32.json
@@ -1,0 +1,43 @@
+{
+  "config": {
+    "concurrency": 8,
+    "total_requests": 40,
+    "unique_prompts": 64,
+    "max_tokens": 64
+  },
+  "wall_time_s": 9.6132,
+  "failures": 0,
+  "latency": {
+    "mean_s": 1.922,
+    "p50_s": 1.9941,
+    "p95_s": 2.1149,
+    "p99_s": 2.1151,
+    "max_s": 2.1151
+  },
+  "throughput": {
+    "total_tokens": 1818,
+    "tokens_per_second": 189.12,
+    "requests_per_second": 4.16
+  },
+  "batching": {
+    "requests": 40,
+    "batches": 5,
+    "average_batch_size": 8.0,
+    "deduplicated": 0,
+    "avg_queue_time_s": 0.039,
+    "avg_ttft_s": 0.1265,
+    "avg_tpot_s": 0.0268
+  },
+  "cache": {
+    "hits": 0,
+    "misses": 40,
+    "hit_rate": 0.0
+  },
+  "title": "Batch size sweep: max_batch_size=32",
+  "env": {
+    "VGATE_MODEL__ENGINE_TYPE": "vllm",
+    "VLLM_WSL2_ENABLE_PIN_MEMORY": "1",
+    "VGATE_BATCH__MAX_BATCH_SIZE": "32",
+    "VGATE_BATCH__MAX_WAIT_TIME_MS": "50"
+  }
+}

--- a/benchmarks/results/vllm/batch_8.json
+++ b/benchmarks/results/vllm/batch_8.json
@@ -1,0 +1,43 @@
+{
+  "config": {
+    "concurrency": 8,
+    "total_requests": 40,
+    "unique_prompts": 64,
+    "max_tokens": 64
+  },
+  "wall_time_s": 6.1817,
+  "failures": 0,
+  "latency": {
+    "mean_s": 1.2358,
+    "p50_s": 1.1936,
+    "p95_s": 1.5264,
+    "p99_s": 1.5268,
+    "max_s": 1.5268
+  },
+  "throughput": {
+    "total_tokens": 1818,
+    "tokens_per_second": 294.09,
+    "requests_per_second": 6.47
+  },
+  "batching": {
+    "requests": 40,
+    "batches": 5,
+    "average_batch_size": 8.0,
+    "deduplicated": 0,
+    "avg_queue_time_s": 0.0004,
+    "avg_ttft_s": 0.0996,
+    "avg_tpot_s": 0.0174
+  },
+  "cache": {
+    "hits": 0,
+    "misses": 40,
+    "hit_rate": 0.0
+  },
+  "title": "Batch size sweep: max_batch_size=8",
+  "env": {
+    "VGATE_MODEL__ENGINE_TYPE": "vllm",
+    "VLLM_WSL2_ENABLE_PIN_MEMORY": "1",
+    "VGATE_BATCH__MAX_BATCH_SIZE": "8",
+    "VGATE_BATCH__MAX_WAIT_TIME_MS": "50"
+  }
+}

--- a/benchmarks/results/vllm/cache_impact.json
+++ b/benchmarks/results/vllm/cache_impact.json
@@ -1,0 +1,43 @@
+{
+  "config": {
+    "concurrency": 8,
+    "total_requests": 40,
+    "unique_prompts": 3,
+    "max_tokens": 64
+  },
+  "wall_time_s": 1.3958,
+  "failures": 0,
+  "latency": {
+    "mean_s": 0.2787,
+    "p50_s": 0.0072,
+    "p95_s": 1.366,
+    "p99_s": 1.3663,
+    "max_s": 1.3663
+  },
+  "throughput": {
+    "total_tokens": 2560,
+    "tokens_per_second": 1834.03,
+    "requests_per_second": 28.66
+  },
+  "batching": {
+    "requests": 8,
+    "batches": 1,
+    "average_batch_size": 8.0,
+    "deduplicated": 5,
+    "avg_queue_time_s": 0.0013,
+    "avg_ttft_s": 0.0,
+    "avg_tpot_s": 0.0173
+  },
+  "cache": {
+    "hits": 32,
+    "misses": 8,
+    "hit_rate": 0.8
+  },
+  "title": "Cache impact: 3 repeated prompts (high reuse) vs. baseline's all-unique prompts",
+  "env": {
+    "VGATE_MODEL__ENGINE_TYPE": "vllm",
+    "VLLM_WSL2_ENABLE_PIN_MEMORY": "1",
+    "VGATE_BATCH__MAX_BATCH_SIZE": "8",
+    "VGATE_BATCH__MAX_WAIT_TIME_MS": "50"
+  }
+}

--- a/benchmarks/results/vllm_baseline.md
+++ b/benchmarks/results/vllm_baseline.md
@@ -1,0 +1,121 @@
+# V-Gate vLLM Benchmark (RTX 3060 Laptop, real GPU)
+
+Generated: 2026-07-30T06:56:04.271430+00:00
+
+> **Real GPU baseline.** NVIDIA GeForce RTX 3060 Laptop GPU (6GB VRAM, ~5GB free), model `Qwen/Qwen2.5-1.5B-Instruct-AWQ`, vLLM 0.26.0, CUDA 12.4, WSL2. This replaces the dry-run-only numbers in `baseline.md` for the batch-size and cache-impact stories.
+>
+> **Two real bugs were found and fixed while producing this data** (see git history for `vgate/backends/vllm_backend.py` and `benchmarks/run_report.py`):
+> 1. vLLM under WSL2 defaults pinned memory off out of caution even on kernels that support it; without `VLLM_WSL2_ENABLE_PIN_MEMORY=1` the engine crashes at startup ("UVA is not available").
+> 2. `VLLMBackend` was reading `metrics.first_token_time`/`arrival_time`/`finished_time`, fields that no longer exist on installed vLLM's `RequestStateStats` (now `first_token_ts`/`last_token_ts`/`first_token_latency`), AND `LLM()` defaults `disable_log_stats=True` unlike `EngineArgs`. Together these meant TTFT/TPOT were silently always 0 for the real vLLM backend before this run — nobody would have noticed without testing against a live GPU.
+>
+> **Known caveat in this data:** `max_batch_size` is a trigger threshold for when `RequestBatcher` starts draining its queue, not a hard cap on how many requests get pulled into one batch (`_process_batch` drains the *entire* current queue). Under concurrent burst arrival, the `max_batch_size=1` scenario below still shows an average realized batch size of 4.0, not 1 — this is a real gap in `vgate/batcher.py`, not a benchmark artifact. The `cache impact` scenario also shows `avg_ttft_s: 0.0`; its single real (non-cached) batch completed fast enough that vLLM's async stats snapshot did not capture a first-token timestamp for it — treat the batch_1/8/32 TTFT numbers as the reliable ones.
+>
+> **Sample size:** each scenario is 24-40 requests / 5-6 batches on a laptop GPU with only one run each — enough to show the batch_1 vs. batch_8 direction clearly, but batch_8 vs. batch_32 (which realize the same avg batch size of 8.0 under this concurrency) differ mostly by run-to-run noise, not a real effect. Don't over-read small deltas between those two.
+
+## Batch size sweep: max_batch_size=1
+
+- Concurrency: 8
+- Total requests: 24
+- Unique prompts: 64
+- Max tokens: 64
+- Failures: 0
+- Wall time: 6.3054s
+
+| Metric | Value |
+|---|---|
+| Latency mean (s) | 2.055 |
+| Latency p50 (s) | 2.1717 |
+| Latency p95 (s) | 2.6624 |
+| Latency p99 (s) | 2.6626 |
+| Latency max (s) | 2.6626 |
+| Tokens/sec | 171.12 |
+| Requests/sec | 3.81 |
+| Avg batch size | 4.0 |
+| Batches formed | 6 |
+| Deduplicated requests | 0 |
+| Avg queue time (s) | 0.9553 |
+| Avg TTFT (s) | 0.0506 |
+| Avg TPOT (s) | 0.0164 |
+| Cache hit rate (this run) | 0.0 |
+| Cache hits / misses (this run) | 0 / 24 |
+
+## Batch size sweep: max_batch_size=8
+
+- Concurrency: 8
+- Total requests: 40
+- Unique prompts: 64
+- Max tokens: 64
+- Failures: 0
+- Wall time: 6.1817s
+
+| Metric | Value |
+|---|---|
+| Latency mean (s) | 1.2358 |
+| Latency p50 (s) | 1.1936 |
+| Latency p95 (s) | 1.5264 |
+| Latency p99 (s) | 1.5268 |
+| Latency max (s) | 1.5268 |
+| Tokens/sec | 294.09 |
+| Requests/sec | 6.47 |
+| Avg batch size | 8.0 |
+| Batches formed | 5 |
+| Deduplicated requests | 0 |
+| Avg queue time (s) | 0.0004 |
+| Avg TTFT (s) | 0.0996 |
+| Avg TPOT (s) | 0.0174 |
+| Cache hit rate (this run) | 0.0 |
+| Cache hits / misses (this run) | 0 / 40 |
+
+## Batch size sweep: max_batch_size=32
+
+- Concurrency: 8
+- Total requests: 40
+- Unique prompts: 64
+- Max tokens: 64
+- Failures: 0
+- Wall time: 9.6132s
+
+| Metric | Value |
+|---|---|
+| Latency mean (s) | 1.922 |
+| Latency p50 (s) | 1.9941 |
+| Latency p95 (s) | 2.1149 |
+| Latency p99 (s) | 2.1151 |
+| Latency max (s) | 2.1151 |
+| Tokens/sec | 189.12 |
+| Requests/sec | 4.16 |
+| Avg batch size | 8.0 |
+| Batches formed | 5 |
+| Deduplicated requests | 0 |
+| Avg queue time (s) | 0.039 |
+| Avg TTFT (s) | 0.1265 |
+| Avg TPOT (s) | 0.0268 |
+| Cache hit rate (this run) | 0.0 |
+| Cache hits / misses (this run) | 0 / 40 |
+
+## Cache impact: 3 repeated prompts (high reuse) vs. baseline's all-unique prompts
+
+- Concurrency: 8
+- Total requests: 40
+- Unique prompts: 3
+- Max tokens: 64
+- Failures: 0
+- Wall time: 1.3958s
+
+| Metric | Value |
+|---|---|
+| Latency mean (s) | 0.2787 |
+| Latency p50 (s) | 0.0072 |
+| Latency p95 (s) | 1.366 |
+| Latency p99 (s) | 1.3663 |
+| Latency max (s) | 1.3663 |
+| Tokens/sec | 1834.03 |
+| Requests/sec | 28.66 |
+| Avg batch size | 8.0 |
+| Batches formed | 1 |
+| Deduplicated requests | 5 |
+| Avg queue time (s) | 0.0013 |
+| Avg TTFT (s) | 0.0 |
+| Avg TPOT (s) | 0.0173 |
+| Cache hit rate (this run) | 0.8 |
+| Cache hits / misses (this run) | 32 / 8 |

--- a/benchmarks/run_report.py
+++ b/benchmarks/run_report.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+# Copyright 2025 the V-Gate authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Generates benchmarks/results/baseline.md by spawning a real V-Gate server
+process per scenario (fresh process per scenario avoids Prometheus's global
+registry rejecting a second app instance in the same process) and driving
+load against it with bench_load.run_load_test().
+
+Scenarios:
+    1. Baseline: default batch config, all-unique prompts (no cache/dedup help).
+    2. Batch size sweep: same workload, max_batch_size in {1, 4, 16, 32}.
+    3. Cache impact: a small pool of repeated prompts vs. the all-unique baseline.
+
+In dry-run mode (default, no GPU) the backend has ~0 real compute cost, so
+batch size would show no effect on its own. VGATE_DRYRUN_SIMULATED_LATENCY_MS
+gives the dry-run backend a synthetic per-call cost (documented, clearly
+labeled in the report) so the batching scenarios are actually comparable.
+This synthetic cost is never applied to vLLM/SGLang backends and never
+affects the test suite (the knob defaults to 0 and only this script sets it).
+
+Usage:
+    python benchmarks/run_report.py
+    python benchmarks/run_report.py --engine-type vllm   # requires GPU + model
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from benchmarks.bench_load import format_markdown, run_load_test  # noqa: E402
+
+RESULTS_DIR = REPO_ROOT / "benchmarks" / "results"
+PORT = 8091
+BASE_URL = f"http://127.0.0.1:{PORT}"
+
+UNIQUE_PROMPTS = [
+    f"Explain distributed systems concept #{i} in one sentence." for i in range(64)
+]
+REPEATED_PROMPTS = [
+    "Explain the concept of machine learning in one paragraph.",
+    "Write a Python function that computes the Fibonacci sequence.",
+    "What are the benefits of using a load balancer?",
+]
+
+
+def _spawn_server(env_overrides: Dict[str, str], log_path: Optional[Path] = None) -> subprocess.Popen:
+    env = os.environ.copy()
+    env.update({
+        "VGATE_SERVER__PORT": str(PORT),
+        "VGATE_SECURITY__ENABLED": "false",
+        "VGATE_TRACING__ENABLED": "false",
+        "VGATE_LOGGING__LEVEL": "WARNING",
+    })
+    env.update(env_overrides)
+    log_file = open(log_path, "w", encoding="utf-8") if log_path else subprocess.DEVNULL
+    return subprocess.Popen(
+        [sys.executable, "main.py"],
+        cwd=str(REPO_ROOT),
+        env=env,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        # New session/process group: vLLM spawns its own EngineCore worker
+        # process via multiprocessing, which does not reliably die when only
+        # the main.py PID is signaled. Killing the whole group on teardown
+        # avoids leaking a GPU-memory-holding zombie between scenarios.
+        start_new_session=True,
+    )
+
+
+def _terminate_process_group(proc: subprocess.Popen) -> None:
+    """Kill the server's whole process group, not just the main.py PID, so
+    vLLM's spawned EngineCore worker (a separate process) can't outlive it
+    and leak GPU memory into the next scenario."""
+    try:
+        pgid = os.getpgid(proc.pid)
+    except ProcessLookupError:
+        return
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.wait(timeout=10)
+    except ProcessLookupError:
+        pass
+
+
+async def _wait_healthy(timeout_s: float) -> None:
+    deadline = time.monotonic() + timeout_s
+    async with aiohttp.ClientSession() as session:
+        while time.monotonic() < deadline:
+            try:
+                async with session.get(
+                    f"{BASE_URL}/health", timeout=aiohttp.ClientTimeout(total=1)
+                ) as resp:
+                    if resp.status == 200:
+                        return
+            except Exception:
+                pass
+            await asyncio.sleep(0.3)
+    raise RuntimeError("Server did not become healthy in time")
+
+
+def _slug(title: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+
+
+async def _run_scenario(
+    title: str,
+    env_overrides: Dict[str, str],
+    concurrency: int,
+    total_requests: int,
+    prompts: List[str],
+    startup_timeout_s: float = 20.0,
+    log_dir: Optional[Path] = None,
+) -> Dict[str, Any]:
+    log_path = (log_dir / f"{_slug(title)}.log") if log_dir else None
+    proc = _spawn_server(env_overrides, log_path)
+    try:
+        await _wait_healthy(startup_timeout_s)
+        result = await run_load_test(
+            base_url=BASE_URL,
+            concurrency=concurrency,
+            total_requests=total_requests,
+            prompts=prompts,
+            max_tokens=64,
+        )
+        result["title"] = title
+        result["env"] = {k: v for k, v in env_overrides.items() if not k.startswith("VGATE_DRYRUN")}
+        return result
+    finally:
+        _terminate_process_group(proc)
+
+
+async def main_async(args: argparse.Namespace) -> None:
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    log_dir = RESULTS_DIR / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.engine_type == "dry-run":
+        base_env = {
+            "VGATE_DRY_RUN": "true",
+            "VGATE_DRYRUN_SIMULATED_LATENCY_MS": str(args.simulated_latency_ms),
+        }
+        startup_timeout_s = 30.0
+    else:
+        base_env = {
+            "VGATE_MODEL__ENGINE_TYPE": args.engine_type,
+            # vLLM defaults pinned memory to off under WSL2 out of caution; this
+            # environment's kernel (>= 4.19.121) and torch.cuda pin_memory() both
+            # verified working, so it's safe to opt back in here. No-op elsewhere.
+            "VLLM_WSL2_ENABLE_PIN_MEMORY": "1",
+        }
+        # Real engines pay full model load + KV cache warmup per scenario
+        # (each scenario is a fresh subprocess); this took ~3 minutes for a
+        # 1.5B AWQ model on an RTX 3060 laptop GPU.
+        startup_timeout_s = 300.0
+
+    scenarios: List[Dict[str, Any]] = []
+
+    scenarios.append(await _run_scenario(
+        "Baseline (max_batch_size=8, all-unique prompts)",
+        {**base_env, "VGATE_BATCH__MAX_BATCH_SIZE": "8", "VGATE_BATCH__MAX_WAIT_TIME_MS": "50"},
+        args.concurrency, args.requests, UNIQUE_PROMPTS, startup_timeout_s, log_dir,
+    ))
+
+    for batch_size in (1, 4, 16, 32):
+        scenarios.append(await _run_scenario(
+            f"Batch size sweep: max_batch_size={batch_size}",
+            {**base_env, "VGATE_BATCH__MAX_BATCH_SIZE": str(batch_size), "VGATE_BATCH__MAX_WAIT_TIME_MS": "50"},
+            args.concurrency, args.requests, UNIQUE_PROMPTS, startup_timeout_s, log_dir,
+        ))
+
+    scenarios.append(await _run_scenario(
+        "Cache impact: 3 repeated prompts (high reuse) vs. baseline's all-unique prompts",
+        {**base_env, "VGATE_BATCH__MAX_BATCH_SIZE": "8", "VGATE_BATCH__MAX_WAIT_TIME_MS": "50"},
+        args.concurrency, args.requests, REPEATED_PROMPTS, startup_timeout_s, log_dir,
+    ))
+
+    lines = [
+        "# V-Gate Benchmark Report",
+        "",
+        f"Generated: {datetime.now(timezone.utc).isoformat()}",
+        f"Engine: {args.engine_type}",
+        f"Concurrency: {args.concurrency}, requests per scenario: {args.requests}",
+        "",
+    ]
+    if args.engine_type == "dry-run":
+        lines += [
+            "> **Dry-run baseline.** No GPU/model is used; the backend is a mock that echoes "
+            f"a fixed response after a synthetic delay of `{args.simulated_latency_ms}ms + 2ms * max_tokens` "
+            "per batch call (see `VGATE_DRYRUN_SIMULATED_LATENCY_MS` in "
+            "`vgate/backends/base.py`). This isolates the batcher/cache/HTTP-layer behavior "
+            "from real inference cost and is **not** a GPU throughput measurement. A "
+            "vLLM/SGLang single-worker baseline on real hardware is still needed "
+            "(`--engine-type vllm|sglang`) before quoting real tokens/sec numbers.",
+            "",
+        ]
+    for s in scenarios:
+        lines.append(format_markdown(s, title=s["title"]))
+
+    md_path = RESULTS_DIR / "baseline.md"
+    json_path = RESULTS_DIR / "baseline.json"
+    md_path.write_text("\n".join(lines), encoding="utf-8")
+    json_path.write_text(json.dumps(scenarios, indent=2), encoding="utf-8")
+    print(f"Report written to {md_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate the V-Gate benchmark report")
+    parser.add_argument("--engine-type", default="dry-run", choices=["dry-run", "vllm", "sglang"])
+    parser.add_argument("--concurrency", type=int, default=8)
+    parser.add_argument("--requests", type=int, default=64)
+    parser.add_argument(
+        "--simulated-latency-ms", type=int, default=15,
+        help="Dry-run only: synthetic per-batch-call base latency in ms",
+    )
+    args = parser.parse_args()
+    asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -309,6 +309,9 @@ async def get_stats():
             "average_batch_size": metrics["average_batch_size"],
             "pending_requests": metrics["pending_requests"],
             "total_deduplicated": metrics["total_deduplicated"],
+            "avg_queue_time_s": metrics["avg_queue_time_s"],
+            "avg_ttft_s": metrics["avg_ttft_s"],
+            "avg_tpot_s": metrics["avg_tpot_s"],
         },
         "cache": metrics["cache"],
         "config": {
@@ -351,8 +354,12 @@ async def run_benchmark(request: BenchmarkRequest):
     max_tokens = request.max_tokens
     rounds = request.rounds
 
+    stats_before = batcher.get_metrics()
+
     latencies: list[float] = []
     token_counts: list[int] = []
+    ttfts: list[float] = []
+    tpots: list[float] = []
 
     for _ in range(rounds):
         round_start = time.perf_counter()
@@ -364,10 +371,27 @@ async def run_benchmark(request: BenchmarkRequest):
         round_latency = time.perf_counter() - round_start
         latencies.append(round_latency)
         token_counts.append(sum(r.get("total_tokens", 0) for r in results))
+        ttfts.extend(r["ttft"] for r in results if r.get("ttft", 0) > 0)
+        tpots.extend(r["tpot"] for r in results if r.get("tpot", 0) > 0)
+
+    stats_after = batcher.get_metrics()
 
     total_tokens = sum(token_counts)
     total_time = sum(latencies)
     sorted_lat = sorted(latencies)
+
+    def _percentile(data: list[float], pct: float) -> float:
+        if not data:
+            return 0.0
+        s = sorted(data)
+        idx = min(int(len(s) * pct / 100), len(s) - 1)
+        return s[idx]
+
+    new_requests = stats_after["total_requests"] - stats_before["total_requests"]
+    new_batches = stats_after["total_batches"] - stats_before["total_batches"]
+    new_dedup = stats_after["total_deduplicated"] - stats_before["total_deduplicated"]
+    new_cache_hits = stats_after["cache"]["hits"] - stats_before["cache"]["hits"]
+    new_cache_misses = stats_after["cache"]["misses"] - stats_before["cache"]["misses"]
 
     return {
         "engine_type": config.model.engine_type,
@@ -378,6 +402,30 @@ async def run_benchmark(request: BenchmarkRequest):
             "p50_s": round(sorted_lat[len(sorted_lat) // 2], 4),
             "p95_s": round(sorted_lat[int(len(sorted_lat) * 0.95)], 4),
             "total_s": round(total_time, 4),
+        },
+        "ttft": {
+            "mean_s": round(sum(ttfts) / len(ttfts), 4) if ttfts else 0,
+            "p50_s": round(_percentile(ttfts, 50), 4),
+            "p95_s": round(_percentile(ttfts, 95), 4),
+        },
+        "tpot": {
+            "mean_s": round(sum(tpots) / len(tpots), 4) if tpots else 0,
+            "p50_s": round(_percentile(tpots, 50), 4),
+            "p95_s": round(_percentile(tpots, 95), 4),
+        },
+        "batching": {
+            "requests": new_requests,
+            "batches": new_batches,
+            "average_batch_size": round(new_requests / new_batches, 2) if new_batches > 0 else 0,
+            "deduplicated": new_dedup,
+        },
+        "cache": {
+            "hits": new_cache_hits,
+            "misses": new_cache_misses,
+            "hit_rate": (
+                round(new_cache_hits / (new_cache_hits + new_cache_misses), 4)
+                if (new_cache_hits + new_cache_misses) > 0 else 0
+            ),
         },
         "throughput": {
             "total_tokens": total_tokens,

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ opentelemetry-exporter-otlp-proto-grpc>=1.25.0
 opentelemetry-instrumentation-fastapi>=0.46b0
 # vllm>=0.14.0  # GPU mode: provided by base image
 # sglang[all]>=0.4.0  # SGLang mode: alternative backend
+
+# Benchmark / concurrent-test tooling (not required to run the server itself)
+aiohttp>=3.9.0

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -143,10 +143,14 @@ class TestVLLMBackendNormalization:
         mock_output.outputs = [MagicMock()]
         mock_output.outputs[0].text = "Generated text"
         mock_output.outputs[0].token_ids = [1, 2, 3, 4, 5]
+        # Field names/semantics match vllm.v1.metrics.stats.RequestStateStats:
+        # first_token_latency is precomputed by vLLM; first_token_ts/last_token_ts
+        # are monotonic engine-core timestamps (arrival_time is a separate
+        # wall-clock frontend timestamp and is not used for these deltas).
         mock_output.metrics = MagicMock()
-        mock_output.metrics.first_token_time = 1.1
-        mock_output.metrics.arrival_time = 1.0
-        mock_output.metrics.finished_time = 1.5
+        mock_output.metrics.first_token_latency = 0.1
+        mock_output.metrics.first_token_ts = 1.1
+        mock_output.metrics.last_token_ts = 1.5
 
         mock_llm = MagicMock()
         mock_llm.generate.return_value = [mock_output]

--- a/tests/test_batcher.py
+++ b/tests/test_batcher.py
@@ -170,6 +170,24 @@ class TestRequestBatcher:
         assert "pending_requests" in metrics
         assert metrics["total_requests"] >= 2
 
+        # Queue time / TTFT / TPOT averages used by the load benchmark report
+        assert metrics["avg_queue_time_s"] >= 0
+        assert metrics["avg_ttft_s"] >= 0
+        assert metrics["avg_tpot_s"] >= 0
+
+        await batcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_queue_time_uses_monotonic_clock(self, batcher):
+        """
+        Queue time must be computed from a monotonic clock, not wall time,
+        so a backward wall-clock adjustment (e.g. NTP correction) can never
+        produce a negative avg_queue_time_s.
+        """
+        await batcher.start()
+        await batcher.submit("Test", max_tokens=50)
+        metrics = batcher.get_metrics()
+        assert metrics["avg_queue_time_s"] >= 0
         await batcher.stop()
 
     @pytest.mark.asyncio

--- a/tests/test_bench_load.py
+++ b/tests/test_bench_load.py
@@ -1,0 +1,84 @@
+# Copyright 2025 the V-Gate authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for benchmarks/bench_load.py's pure aggregation/formatting logic.
+
+The concurrent HTTP load path (run_load_test) needs a real running server
+(aiohttp requires a real socket, unlike httpx's ASGI transport) and is
+exercised end-to-end by benchmarks/run_report.py; it is not re-tested here
+to keep this suite fast and GPU-free.
+"""
+
+from benchmarks.bench_load import _percentile, format_markdown, load_prompts, DEFAULT_PROMPTS
+
+
+class TestPercentile:
+    def test_empty(self):
+        assert _percentile([], 50) == 0.0
+
+    def test_single_value(self):
+        assert _percentile([1.5], 99) == 1.5
+
+    def test_p50_matches_median_for_odd_length(self):
+        assert _percentile([1.0, 2.0, 3.0], 50) == 2.0
+
+    def test_p99_clamps_to_max(self):
+        data = [float(i) for i in range(10)]
+        assert _percentile(data, 99) == max(data)
+
+
+class TestLoadPrompts:
+    def test_no_file_returns_defaults(self):
+        assert load_prompts(None) == DEFAULT_PROMPTS
+
+    def test_reads_nonempty_lines(self, tmp_path):
+        p = tmp_path / "prompts.txt"
+        p.write_text("first prompt\n\n  second prompt  \n", encoding="utf-8")
+        assert load_prompts(str(p)) == ["first prompt", "second prompt"]
+
+    def test_blank_file_falls_back_to_defaults(self, tmp_path):
+        p = tmp_path / "empty.txt"
+        p.write_text("\n\n  \n", encoding="utf-8")
+        assert load_prompts(str(p)) == DEFAULT_PROMPTS
+
+
+class TestFormatMarkdown:
+    def _sample_result(self):
+        return {
+            "config": {"concurrency": 4, "total_requests": 20, "unique_prompts": 3, "max_tokens": 64},
+            "wall_time_s": 1.234,
+            "failures": 0,
+            "latency": {"mean_s": 0.1, "p50_s": 0.09, "p95_s": 0.2, "p99_s": 0.25, "max_s": 0.3},
+            "throughput": {"total_tokens": 100, "tokens_per_second": 81.0, "requests_per_second": 16.0},
+            "batching": {
+                "requests": 20, "batches": 4, "average_batch_size": 5.0, "deduplicated": 2,
+                "avg_queue_time_s": 0.01, "avg_ttft_s": 0.0, "avg_tpot_s": 0.005,
+            },
+            "cache": {"hits": 5, "misses": 15, "hit_rate": 0.25},
+        }
+
+    def test_contains_title_and_key_metrics(self):
+        md = format_markdown(self._sample_result(), title="My Scenario")
+        assert "## My Scenario" in md
+        assert "0.1" in md  # latency mean
+        assert "81.0" in md  # tokens/sec
+        assert "0.25" in md  # cache hit rate
+
+    def test_no_failures_data_missing_keyerror(self):
+        # Guard against KeyError regressions when a caller passes a
+        # freshly-built result dict from run_load_test.
+        result = self._sample_result()
+        md = format_markdown(result)
+        assert isinstance(md, str) and len(md) > 0

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -110,6 +110,10 @@ class TestBenchmarkEndpoint:
             assert "latency" in data
             assert "throughput" in data
             assert data["rounds"] == 3  # default
+            assert "ttft" in data and "p50_s" in data["ttft"] and "p95_s" in data["ttft"]
+            assert "tpot" in data and "p50_s" in data["tpot"] and "p95_s" in data["tpot"]
+            assert "batching" in data and "average_batch_size" in data["batching"]
+            assert "cache" in data and "hit_rate" in data["cache"]
 
     @pytest.mark.asyncio
     async def test_benchmark_endpoint_custom(self):

--- a/vgate/backends/base.py
+++ b/vgate/backends/base.py
@@ -12,9 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import time
 from typing import Any, Dict, List, Protocol, runtime_checkable
 
 from vgate.config import ModelConfig
+
+# Optional synthetic per-call delay for the dry-run backend, used only by
+# benchmarks/run_report.py to give dry-run batching scenarios a non-zero
+# compute cost to amortize. Unset (0) by default, so it never affects tests.
+_DRYRUN_LATENCY_MS = float(os.getenv("VGATE_DRYRUN_SIMULATED_LATENCY_MS", "0"))
+
+
+def _simulate_batch_compute(sampling_params: Any) -> None:
+    if _DRYRUN_LATENCY_MS <= 0:
+        return
+    max_tokens = sampling_params.get("max_tokens", 0) if isinstance(sampling_params, dict) else 0
+    time.sleep((_DRYRUN_LATENCY_MS + max_tokens * 2) / 1000.0)
 
 
 @runtime_checkable
@@ -48,6 +62,7 @@ class DryRunBackend:
     def generate(
         self, prompts: List[str], sampling_params: Any
     ) -> List[Dict[str, Any]]:
+        _simulate_batch_compute(sampling_params)
         results = []
         for prompt in prompts:
             results.append({

--- a/vgate/backends/vllm_backend.py
+++ b/vgate/backends/vllm_backend.py
@@ -34,6 +34,10 @@ class VLLMBackend:
             max_model_len=model_config.max_model_len,
             enforce_eager=model_config.enforce_eager,
             trust_remote_code=model_config.trust_remote_code,
+            # LLM() defaults this to True (unlike EngineArgs), which leaves
+            # output.metrics as None for every request and silently zeroes
+            # out TTFT/TPOT.
+            disable_log_stats=False,
         )
 
     def create_sampling_params(
@@ -58,8 +62,12 @@ class VLLMBackend:
             metrics_dict = {}
             metrics = output.metrics
             if metrics:
-                metrics_dict["ttft"] = metrics.first_token_time - metrics.arrival_time
-                metrics_dict["gen_time"] = metrics.finished_time - metrics.first_token_time
+                # first_token_latency is precomputed by vLLM; first_token_ts/
+                # last_token_ts are monotonic engine-core timestamps, safe to
+                # subtract (unlike arrival_time, which is a wall-clock
+                # frontend timestamp from a different clock domain).
+                metrics_dict["ttft"] = metrics.first_token_latency
+                metrics_dict["gen_time"] = metrics.last_token_ts - metrics.first_token_ts
 
             results.append({
                 "text": text,

--- a/vgate/batcher.py
+++ b/vgate/batcher.py
@@ -41,7 +41,7 @@ class BatchRequest:
     top_p: float = 0.9
     cache_key: str = ""
     future: asyncio.Future = field(default_factory=lambda: asyncio.get_event_loop().create_future())
-    created_at: float = field(default_factory=time.time)
+    created_at: float = field(default_factory=time.monotonic)  # monotonic: used only for queue-time deltas
 
 
 class RequestBatcher:
@@ -85,6 +85,11 @@ class RequestBatcher:
         self.total_batches = 0
         self.total_batch_size = 0
         self.total_deduplicated = 0
+        self.total_queue_time = 0.0
+        self.total_queue_samples = 0
+        self.total_ttft = 0.0
+        self.total_tpot = 0.0
+        self.total_inference_samples = 0
 
     async def start(self):
         """Start the background batching task."""
@@ -164,7 +169,7 @@ class RequestBatcher:
                 top_p=top_p,
                 cache_key=cache_key,
                 future=asyncio.get_event_loop().create_future(),
-                created_at=time.time(),
+                created_at=time.monotonic(),
             )
 
             async with self._lock:
@@ -217,11 +222,13 @@ class RequestBatcher:
                 span.set_attribute("batch_id", self.total_batches)
                 span.set_attribute("batch_size", batch_size)
 
-                # Calculate queue wait times
-                current_time = time.time()
+                # Calculate queue wait times (monotonic: immune to wall-clock adjustments)
+                current_time = time.monotonic()
                 for req in batch:
                     queue_time = current_time - req.created_at
                     BATCH_QUEUE_TIME.observe(queue_time)
+                    self.total_queue_time += queue_time
+                    self.total_queue_samples += 1
 
                 logger.info(
                     "Processing batch",
@@ -282,8 +289,11 @@ class RequestBatcher:
                     for result in results:
                         if result.get("ttft", 0) > 0:
                             TTFT.observe(result["ttft"])
+                            self.total_ttft += result["ttft"]
                         if result.get("tpot", 0) > 0:
                             TPOT.observe(result["tpot"])
+                            self.total_tpot += result["tpot"]
+                            self.total_inference_samples += 1
                         tokens = result.get("total_tokens", 0)
                         TOKENS_GENERATED.inc(tokens)
                         total_tokens += tokens
@@ -401,11 +411,23 @@ class RequestBatcher:
     def get_metrics(self) -> Dict[str, Any]:
         """Return batching metrics including cache stats."""
         avg_batch_size = (self.total_batch_size / self.total_batches) if self.total_batches > 0 else 0
+        avg_queue_time = (
+            self.total_queue_time / self.total_queue_samples if self.total_queue_samples > 0 else 0
+        )
+        avg_ttft = (
+            self.total_ttft / self.total_inference_samples if self.total_inference_samples > 0 else 0
+        )
+        avg_tpot = (
+            self.total_tpot / self.total_inference_samples if self.total_inference_samples > 0 else 0
+        )
         return {
             "total_requests": self.total_requests,
             "total_batches": self.total_batches,
             "average_batch_size": round(avg_batch_size, 2),
             "pending_requests": len(self._queue),
             "total_deduplicated": self.total_deduplicated,
+            "avg_queue_time_s": round(avg_queue_time, 4),
+            "avg_ttft_s": round(avg_ttft, 4),
+            "avg_tpot_s": round(avg_tpot, 4),
             "cache": self.cache.get_stats(),
         }


### PR DESCRIPTION
## Summary
- Adds `benchmarks/bench_load.py` (concurrent HTTP load generator against a running server) and `benchmarks/run_report.py` (multi-scenario orchestrator: batch-size sweep, cache/dedup impact), producing markdown reports with p50/p95/p99 latency, TTFT/TPOT, and batch/cache stats.
- `RequestBatcher` now tracks `avg_queue_time_s`/`avg_ttft_s`/`avg_tpot_s`; `/v1/benchmark` surfaces the same stats plus TTFT/TPOT percentiles.
- Ships both a dry-run baseline (`benchmarks/results/baseline.md`) and a **real GPU baseline** (`benchmarks/results/vllm_baseline.md`: RTX 3060 Laptop, `Qwen2.5-1.5B-Instruct-AWQ`, vLLM 0.26).
- Fixes 3 bugs only visible against live hardware/dependencies, found while producing the real baseline:
  - `RequestBatcher` used `time.time()` for a queue-time duration delta, which can go negative on wall-clock adjustment (observed under WSL2) — switched to `time.monotonic()`.
  - vLLM disables pinned memory by default under WSL2 even on kernels that support it, crashing at startup (`UVA is not available`) — documented the `VLLM_WSL2_ENABLE_PIN_MEMORY=1` workaround.
  - `VLLMBackend` read vLLM metrics fields renamed upstream, and `LLM()` defaults `disable_log_stats=True` (unlike `EngineArgs`) — TTFT/TPOT were silently always 0 for the real vLLM backend before this fix.
- Documents a known, unfixed gap this surfaced: `max_batch_size` is a trigger threshold, not an enforced cap — `_process_batch` drains the whole queue, so realized batch size can exceed the configured value under concurrent burst arrival.

## Test plan
- [x] `PYTHONPATH=. VGATE_DRY_RUN=true pytest tests/ -v` — 138 passed
- [x] Real vLLM smoke test: chat completion against a live-loaded `Qwen2.5-1.5B-Instruct-AWQ` on GPU returned a correct response
- [x] `benchmarks/run_report.py` generates `baseline.md` end-to-end in dry-run mode
- [x] 4 real-GPU scenarios (batch_size 1/8/32, cache impact) run individually via `benchmarks/_run_scenario_cli.py` and aggregated into `vllm_baseline.md`
- [x] Confirmed no orphaned `EngineCore` GPU-memory-holding processes after each scenario teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)