### PR TITLE
Phase 0 credibility fixes: cache, batching correctness, CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,43 @@
+name: Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  server-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio
+
+      - name: Run tests (dry-run mode, no GPU)
+        env:
+          PYTHONPATH: .
+          VGATE_DRY_RUN: "true"
+        run: pytest tests/ -v
+
+  client-sdk-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install client SDK with dev dependencies
+        run: pip install -e "./vgate-client[dev]"
+
+      - name: Run client SDK tests
+        run: pytest vgate-client/tests/ -v

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # V-Gate
 
+[![Tests](https://github.com/Kare0638/V-Gate/actions/workflows/tests.yml/badge.svg)](https://github.com/Kare0638/V-Gate/actions/workflows/tests.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![Docker](https://img.shields.io/badge/docker-ready-blue.svg)](https://www.docker.com/)
 
-**V-Gate** is a high-performance AI model serving gateway with pluggable inference backends. It currently supports [vLLM](https://github.com/vllm-project/vllm) and [SGLang](https://github.com/sgl-project/sglang), while exposing a unified OpenAI-compatible API with enterprise-grade features including dynamic request batching, result caching, observability, and security.
+**V-Gate** is a high-performance AI model serving gateway with pluggable inference backends. It currently supports [vLLM](https://github.com/vllm-project/vllm) and [SGLang](https://github.com/sgl-project/sglang), while exposing a unified OpenAI-compatible API with enterprise-grade features including dynamic micro-batching, result caching, observability, and security.
 
 Optimized for memory-constrained environments (e.g., RTX 3060/4060).
 
@@ -14,8 +15,8 @@ Optimized for memory-constrained environments (e.g., RTX 3060/4060).
 
 | Feature | Description |
 |---------|-------------|
-| **OpenAI-Compatible API** | Drop-in replacement for OpenAI API (`/v1/chat/completions`, `/v1/embeddings`) |
-| **Dynamic Request Batching** | Aggregate concurrent requests for improved GPU utilization |
+| **OpenAI-Compatible API** | OpenAI-style API surface (`/v1/chat/completions`, `/v1/embeddings`) |
+| **Dynamic Micro-Batching** | Aggregate queued requests into static backend batches for improved throughput |
 | **Result Caching** | LRU cache with batch-level deduplication |
 | **Multi-Backend Inference** | Switch backend with `model.engine_type` (`vllm` / `sglang`) |
 | **Built-in Benchmarking** | Compare backends with CLI tool and `/v1/benchmark` API |
@@ -26,6 +27,18 @@ Optimized for memory-constrained environments (e.g., RTX 3060/4060).
 | **Configuration as Code** | YAML configuration with environment variable overrides |
 | **Docker Ready** | Multi-stage build with GPU and CPU targets |
 | **Python Client SDK** | `pip install` ready client with sync/async support |
+
+Note: `/v1/embeddings` currently returns a mock 1536-dimensional embedding for MVP/testing workflows. A real embedding backend is planned but not implemented yet.
+
+---
+
+## Documentation
+
+- [Roadmap](ROADMAP.md): staged engineering plan from the current gateway to reliable distributed inference serving.
+- [Documentation index](docs/README.md): public docs and status conventions.
+- [Advanced roadmap](docs/design/ADVANCED_ROADMAP.md): superseded by ROADMAP.md; kept for historical reference on reliability, scaling, and governance ideas.
+- [V2 architecture proposal](docs/design/V2_ARCHITECTURE_PROPOSAL.md): design proposal for future C++/CUDA data-plane work.
+- [Containerization test report](docs/reports/CONTAINERIZATION_TEST_REPORT.md): Docker validation notes.
 
 ---
 
@@ -390,9 +403,14 @@ V-Gate/
 ├── Dockerfile              # Multi-stage Docker build
 ├── docker-compose.yml      # Service orchestration
 ├── requirements.txt        # Python dependencies
+├── ROADMAP.md              # Public engineering roadmap
 ├── benchmarks/
 │   ├── benchmark.py         # Single-engine benchmark entry
 │   └── bench_compare.py     # Multi-backend benchmark comparison CLI
+├── docs/
+│   ├── README.md            # Documentation index
+│   ├── design/              # Architecture and roadmap proposals
+│   └── reports/             # Validation and test reports
 ├── vgate/
 │   ├── __init__.py
 │   ├── engine.py           # Backend factory + engine wrapper
@@ -449,6 +467,8 @@ VGATE_DRY_RUN=true pytest tests/test_backends.py -k vllm -v
 VGATE_DRY_RUN=true ./.venv-sglang/bin/pytest tests/test_backends.py -k sglang -v
 ```
 
+CI ([`.github/workflows/tests.yml`](.github/workflows/tests.yml)) runs the same dry-run suite plus the client SDK tests (`vgate-client/tests/`) on every push/PR to `main`.
+
 ### Code Style
 
 ```bash
@@ -465,7 +485,7 @@ ruff check .
 
 - [x] **Phase 1**: Core MVP - Unified API Gateway
 - [x] **Phase 2**: Performance Optimization
-  - [x] 2.1 Dynamic Request Batching
+  - [x] 2.1 Dynamic Micro-Batching
   - [x] 2.2 Result Caching
   - [ ] 2.3 Multi-Worker Load Balancing
 - [x] **Phase 3**: Production-Grade Features
@@ -475,7 +495,9 @@ ruff check .
 - [x] **Phase 4**: Ecosystem & Deployment
   - [x] 4.1 Containerization (Docker)
   - [x] 4.2 Python Client SDK
-  - [ ] 4.3 Kubernetes Deployment
+  - [x] 4.3 Kubernetes manifests
+
+See [ROADMAP.md](ROADMAP.md) for the next engineering milestones, including streaming with engine-native continuous batching, benchmark-gated sqlite L2 cache, backpressure, multi-worker routing, and low-level performance work.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,6 @@ Current gaps:
 
 - OpenAI API compatibility is still shallow; streaming is missing.
 - Current batching is static micro-batching, not true continuous batching. New requests cannot join an already-running decode batch.
-- `max_batch_size` is a trigger threshold, not an enforced cap — `_process_batch` drains the entire queue when it fires, so realized batch sizes can exceed the configured value under concurrent burst arrival (confirmed on real hardware, see `benchmarks/results/vllm_baseline.md`).
 - The runtime is still a single gateway with a single local backend, not real multi-worker serving.
 - Benchmark tooling exists, but systematic benchmark reports and analysis are missing.
 - Cache is RAM-only. There is no persistent local disk cache layer, and cache value depends on process lifetime.
@@ -113,6 +112,15 @@ Completion criteria:
 
 ### Phase 0: Credibility Fixes
 
+**Status: done.** All six tasks are implemented and covered by tests (`pytest tests/ vgate-client/tests/` — 146 + 48 passing):
+
+1. `cache.enabled=False` now makes `ResultCache.get/put` a true no-op instead of being silently ignored.
+2. `RequestBatcher._process_batch` now groups deduplicated requests by `(temperature, top_p, max_tokens)` and dispatches one backend call per group, so requests with different sampling params can no longer silently share (and corrupt) each other's params. Fixing this also fixed the `max_batch_size`-is-only-a-trigger gap noted in Phase 1: `_process_batch` now drains at most `max_batch_size` requests per call instead of the whole queue, and `stop()` loops until the queue is fully drained so a burst larger than one batch can't strand unresolved requests on shutdown.
+3. `RequestBatcher.submit()` takes an optional `timeout` and cleans up the queue entry on both `asyncio.TimeoutError` and caller-side cancellation.
+4. `ChatCompletionRequest.messages` is now `list[ChatMessage]` (was a bare, unvalidated `list`) — a malformed message now returns 422 instead of an unhandled 500 (`'str' object has no attribute 'get'`).
+5. README documents `/v1/embeddings` as a mock MVP implementation.
+6. `.github/workflows/tests.yml` runs the dry-run server suite and the client SDK suite on every push/PR to `main`.
+
 Priority: highest.
 
 Reason: these issues affect project trust. Fix the semantics of the main path before expanding the architecture.
@@ -152,7 +160,7 @@ Expected outcome:
 
 **Status: done.** `benchmarks/bench_load.py` (concurrent HTTP load generator) and `benchmarks/run_report.py` (multi-scenario orchestrator) are implemented; `benchmarks/results/baseline.md` (dry-run) and `benchmarks/results/vllm_baseline.md` (real GPU: RTX 3060 Laptop, Qwen2.5-1.5B-AWQ, vLLM 0.26) are both checked in. Batcher tracks `avg_queue_time_s`/`avg_ttft_s`/`avg_tpot_s` and `/v1/benchmark` reports TTFT/TPOT percentiles plus batch/cache stats.
 
-Producing the real GPU baseline surfaced and fixed three bugs that only show up against live hardware/dependencies: (1) `time.time()` for queue-time deltas could go negative on wall-clock adjustment, now `time.monotonic()`; (2) vLLM under WSL2 needs `VLLM_WSL2_ENABLE_PIN_MEMORY=1` or it crashes at startup; (3) `VLLMBackend` read renamed/removed vLLM metrics fields plus relied on a stats-collection flag that `LLM()` defaults off, so TTFT/TPOT were silently always 0 for the real backend. It also surfaced (not yet fixed): `max_batch_size` in `vgate/batcher.py` is only a trigger threshold, not a hard cap — `_process_batch` drains the entire queue regardless of the configured size, so realized batch sizes can exceed it under concurrent burst arrival. See `benchmarks/results/vllm_baseline.md` for the data.
+Producing the real GPU baseline surfaced and fixed three bugs that only show up against live hardware/dependencies: (1) `time.time()` for queue-time deltas could go negative on wall-clock adjustment, now `time.monotonic()`; (2) vLLM under WSL2 needs `VLLM_WSL2_ENABLE_PIN_MEMORY=1` or it crashes at startup; (3) `VLLMBackend` read renamed/removed vLLM metrics fields plus relied on a stats-collection flag that `LLM()` defaults off, so TTFT/TPOT were silently always 0 for the real backend. It also surfaced a fourth issue, fixed in Phase 0: `max_batch_size` was only a trigger threshold, not a hard cap. See `benchmarks/results/vllm_baseline.md` for the original data.
 
 Priority: highest.
 

--- a/main.py
+++ b/main.py
@@ -173,9 +173,14 @@ async def observability_middleware(request: Request, call_next):
 
 
 # Request models for OpenAI-like API
+class ChatMessage(BaseModel):
+    role: str
+    content: str
+
+
 class ChatCompletionRequest(BaseModel):
     model: str
-    messages: list
+    messages: list[ChatMessage]
     temperature: float = 0.7
     top_p: float = 0.9
     max_tokens: int = 256
@@ -187,12 +192,8 @@ class EmbeddingRequest(BaseModel):
 
 
 # Helper function to convert messages to a prompt string
-def messages_to_prompt(messages: list) -> str:
-    prompt_parts = []
-    for message in messages:
-        role = message.get("role", "user")
-        content = message.get("content", "")
-        prompt_parts.append(f"{role.capitalize()}: {content}")
+def messages_to_prompt(messages: list[ChatMessage]) -> str:
+    prompt_parts = [f"{m.role.capitalize()}: {m.content}" for m in messages]
     return "\n".join(prompt_parts) + "\nAssistant:"
 
 

--- a/tests/test_batcher.py
+++ b/tests/test_batcher.py
@@ -29,11 +29,17 @@ from vgate.batcher import RequestBatcher, BatchRequest
 class MockBackend:
     """Mock inference backend for testing without GPU."""
 
+    def __init__(self):
+        # Records (prompts, sampling_params) for every generate() call, so
+        # tests can assert on how requests were actually grouped/dispatched.
+        self.calls = []
+
     def create_sampling_params(self, temperature, top_p, max_tokens):
         return {"temperature": temperature, "top_p": top_p, "max_tokens": max_tokens}
 
     def generate(self, prompts, sampling_params):
         """Simulate batch generation with standardized dict output."""
+        self.calls.append((list(prompts), dict(sampling_params)))
         results = []
         for prompt in prompts:
             results.append({
@@ -154,6 +160,52 @@ class TestRequestBatcher:
         await batcher.stop()
 
     @pytest.mark.asyncio
+    async def test_max_batch_size_is_hard_cap(self, batcher):
+        """No single generate() call should receive more than max_batch_size prompts.
+
+        _process_batch used to drain the entire queue regardless of
+        max_batch_size (only using it as a trigger threshold), so a burst of
+        concurrent requests could produce a call larger than configured.
+        """
+        await batcher.start()
+
+        tasks = [
+            batcher.submit(f"Unique question {i}", max_tokens=50)
+            for i in range(10)  # max_batch_size is 4
+        ]
+        await asyncio.gather(*tasks)
+
+        assert len(batcher.engine.backend.calls) >= 1
+        for prompts, _ in batcher.engine.backend.calls:
+            assert len(prompts) <= batcher.max_batch_size
+
+        await batcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_different_sampling_params_not_mixed(self, batcher):
+        """Requests with different temperature/top_p/max_tokens landing in the
+        same drained batch must not share a single generate() call — a shared
+        SamplingParams would silently apply the wrong params to some prompts.
+        """
+        await batcher.start()
+
+        tasks = [
+            batcher.submit("Prompt hot", max_tokens=50, temperature=1.0, top_p=0.9),
+            batcher.submit("Prompt cold", max_tokens=50, temperature=0.0, top_p=0.9),
+        ]
+        await asyncio.gather(*tasks)
+
+        calls_by_prompt = {}
+        for prompts, sampling_params in batcher.engine.backend.calls:
+            for prompt in prompts:
+                calls_by_prompt[prompt] = sampling_params
+
+        assert calls_by_prompt["Prompt hot"]["temperature"] == 1.0
+        assert calls_by_prompt["Prompt cold"]["temperature"] == 0.0
+
+        await batcher.stop()
+
+    @pytest.mark.asyncio
     async def test_metrics_tracking(self, batcher):
         """Test metrics are tracked correctly."""
         await batcher.start()
@@ -189,6 +241,37 @@ class TestRequestBatcher:
         metrics = batcher.get_metrics()
         assert metrics["avg_queue_time_s"] >= 0
         await batcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_submit_timeout_raises_and_cleans_up_queue(self, mock_engine):
+        """A submit() timeout must raise and remove the request from the
+        queue, not leave a dead entry that would occupy a future batch slot."""
+        # max_batch_size high enough, and no start(), so nothing ever drains
+        # the queue: submit() has no way to resolve except the timeout.
+        batcher = RequestBatcher(engine=mock_engine, max_batch_size=100, max_wait_time_ms=50000.0)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await batcher.submit("Never processed", max_tokens=50, timeout=0.05)
+
+        assert len(batcher._queue) == 0
+        assert batcher.get_metrics()["pending_requests"] == 0
+
+    @pytest.mark.asyncio
+    async def test_submit_cancellation_cleans_up_queue(self, mock_engine):
+        """Cancelling the caller's task while awaiting submit() must remove
+        the request from the queue instead of leaking it."""
+        batcher = RequestBatcher(engine=mock_engine, max_batch_size=100, max_wait_time_ms=50000.0)
+
+        task = asyncio.create_task(batcher.submit("Never processed", max_tokens=50))
+        await asyncio.sleep(0.01)  # let it enqueue
+        assert len(batcher._queue) == 1
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert len(batcher._queue) == 0
+        assert batcher.get_metrics()["pending_requests"] == 0
 
     @pytest.mark.asyncio
     async def test_timeout_triggers_batch(self, batcher):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -148,6 +148,20 @@ class TestResultCache:
         assert result_b is None  # Evicted
         assert result_c is not None
 
+    @pytest.mark.asyncio
+    async def test_disabled_cache_is_noop(self):
+        """cache.enabled=False must make get/put a no-op, not just a stats label."""
+        cache = ResultCache(CacheConfig(enabled=False, maxsize=10))
+        key = ResultCache.make_key("Hello", 0.7, 0.9, 256)
+
+        await cache.put(key, {"text": "World"})
+        result = await cache.get(key)
+
+        assert result is None
+        assert cache.get_stats()["size"] == 0
+        assert cache.hits == 0
+        assert cache.misses == 0
+
 
 class MockBackend:
     """Mock inference backend for testing without GPU."""

--- a/tests/test_chat_completions.py
+++ b/tests/test_chat_completions.py
@@ -1,0 +1,81 @@
+# Copyright 2025 the V-Gate authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for /v1/chat/completions request validation.
+
+ChatCompletionRequest.messages used to be a bare `list`, so a malformed
+message (missing "role"/"content", or not a dict at all) would pass
+validation and then blow up as an unhandled 500 in messages_to_prompt()
+instead of a clean 422.
+"""
+
+import pytest
+
+from vgate.config import reset_config
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_config()
+    yield
+    reset_config()
+
+
+class TestChatCompletionValidation:
+    @pytest.mark.asyncio
+    async def test_well_formed_messages_succeed(self):
+        from httpx import ASGITransport, AsyncClient
+        from main import app, lifespan
+
+        async with lifespan(app):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post("/v1/chat/completions", json={
+                    "model": "test-model",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                })
+
+            assert response.status_code == 200
+            assert "choices" in response.json()
+
+    @pytest.mark.asyncio
+    async def test_message_missing_content_returns_422_not_500(self):
+        from httpx import ASGITransport, AsyncClient
+        from main import app, lifespan
+
+        async with lifespan(app):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post("/v1/chat/completions", json={
+                    "model": "test-model",
+                    "messages": [{"role": "user"}],
+                })
+
+            assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_message_not_an_object_returns_422_not_500(self):
+        from httpx import ASGITransport, AsyncClient
+        from main import app, lifespan
+
+        async with lifespan(app):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post("/v1/chat/completions", json={
+                    "model": "test-model",
+                    "messages": ["just a string, not a message object"],
+                })
+
+            assert response.status_code == 422

--- a/vgate/batcher.py
+++ b/vgate/batcher.py
@@ -114,8 +114,12 @@ class RequestBatcher:
                 await self._batch_task
             except asyncio.CancelledError:
                 pass
-        # Process any remaining requests
-        await self._process_batch()
+        # Process any remaining requests. _process_batch only drains up to
+        # max_batch_size per call, so loop until the queue is fully empty —
+        # otherwise a queue longer than max_batch_size would strand requests
+        # with unresolved futures on shutdown.
+        while self._queue:
+            await self._process_batch()
         logger.info("Batcher stopped")
 
     async def submit(
@@ -124,6 +128,7 @@ class RequestBatcher:
         max_tokens: Optional[int] = None,
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
+        timeout: Optional[float] = None,
     ) -> Dict[str, Any]:
         """
         Submit a request for batched processing.
@@ -135,6 +140,13 @@ class RequestBatcher:
             max_tokens: Max tokens to generate. Uses config default if None.
             temperature: Sampling temperature. Uses config default if None.
             top_p: Top-p sampling. Uses config default if None.
+            timeout: Max seconds to wait for a result. Raises
+                asyncio.TimeoutError and removes the request from the queue
+                if it hasn't been picked up by a batch yet. No timeout if None.
+
+        Raises:
+            asyncio.TimeoutError: if `timeout` elapses before a result is ready.
+            asyncio.CancelledError: if the calling task is cancelled while waiting.
         """
         with tracer.start_as_current_span("batcher.submit") as span:
             # Apply defaults from config
@@ -183,8 +195,23 @@ class RequestBatcher:
                 asyncio.create_task(self._process_batch())
 
             # Wait for result
-            result = await request.future
-            return result
+            try:
+                if timeout is not None:
+                    result = await asyncio.wait_for(request.future, timeout=timeout)
+                else:
+                    result = await request.future
+                return result
+            finally:
+                # Best-effort cleanup: if this request timed out, was
+                # cancelled, or errored before a batch picked it up, remove
+                # it from the queue instead of leaving a dead entry that
+                # would still occupy a batch slot later. No-op if it was
+                # already dequeued for processing.
+                async with self._lock:
+                    before = len(self._queue)
+                    self._queue = [r for r in self._queue if r is not request]
+                    if len(self._queue) != before:
+                        PENDING_REQUESTS.set(len(self._queue))
 
     async def _batch_loop(self):
         """Background loop that triggers batch processing on timeout."""
@@ -195,17 +222,21 @@ class RequestBatcher:
                 await self._process_batch()
 
     async def _process_batch(self):
-        """Process all pending requests as a batch with deduplication."""
+        """Process up to max_batch_size pending requests as a batch, with deduplication."""
         # Use inference lock to prevent concurrent vLLM calls
         async with self._inference_lock:
             async with self._lock:
                 if not self._queue:
                     return
 
-                # Take all pending requests
-                batch = self._queue[:]
-                self._queue.clear()
-                PENDING_REQUESTS.set(0)
+                # Take at most max_batch_size requests; leave any excess
+                # queued for the next drain instead of unboundedly growing
+                # the batch (submit() re-triggers processing whenever the
+                # queue is at/above max_batch_size, so leftovers get picked
+                # up promptly rather than waiting for the next timeout tick).
+                batch = self._queue[:self.max_batch_size]
+                self._queue = self._queue[self.max_batch_size:]
+                PENDING_REQUESTS.set(len(self._queue))
 
             if not batch:
                 return
@@ -239,21 +270,16 @@ class RequestBatcher:
                 )
 
                 try:
-                    # Group requests by cache_key for deduplication
+                    # Group requests by cache_key for deduplication (same key
+                    # implies identical prompt + temperature + top_p + max_tokens).
                     unique_prompts: Dict[str, List[BatchRequest]] = {}
                     for req in batch:
                         if req.cache_key not in unique_prompts:
                             unique_prompts[req.cache_key] = []
                         unique_prompts[req.cache_key].append(req)
 
-                    # Only infer unique prompts
-                    prompts_to_infer = [reqs[0].prompt for reqs in unique_prompts.values()]
-                    temps_to_infer = [reqs[0].temperature for reqs in unique_prompts.values()]
-                    top_ps_to_infer = [reqs[0].top_p for reqs in unique_prompts.values()]
-                    max_tokens = max(req.max_tokens for req in batch)
-
-                    dedup_count = batch_size - len(prompts_to_infer)
-                    span.set_attribute("unique_prompts", len(prompts_to_infer))
+                    dedup_count = batch_size - len(unique_prompts)
+                    span.set_attribute("unique_prompts", len(unique_prompts))
                     span.set_attribute("deduplicated", dedup_count)
 
                     if dedup_count > 0:
@@ -264,58 +290,67 @@ class RequestBatcher:
                             "Deduplicated requests",
                             extra={"extra_data": {
                                 "deduplicated": dedup_count,
-                                "unique_prompts": len(prompts_to_infer)
+                                "unique_prompts": len(unique_prompts)
                             }}
                         )
                     else:
                         DEDUP_RATIO.set(0)
 
-                    UNIQUE_PROMPTS_PER_BATCH.observe(len(prompts_to_infer))
+                    UNIQUE_PROMPTS_PER_BATCH.observe(len(unique_prompts))
 
-                    # Process batch through engine
-                    batch_start = time.perf_counter()
-                    results = await self._run_batch_inference(
-                        prompts_to_infer, max_tokens, temps_to_infer[0], top_ps_to_infer[0]
-                    )
-                    batch_duration = time.perf_counter() - batch_start
+                    # A single backend.generate() call applies one shared
+                    # SamplingParams to every prompt it's given, so requests
+                    # with different (temperature, top_p, max_tokens) cannot
+                    # share a call — group deduplicated requests by their
+                    # params and dispatch one call per group.
+                    params_groups: Dict[tuple, List[str]] = {}
+                    for cache_key, reqs in unique_prompts.items():
+                        params_key = (reqs[0].temperature, reqs[0].top_p, reqs[0].max_tokens)
+                        params_groups.setdefault(params_key, []).append(cache_key)
 
-                    # Exemplar for metric-trace correlation
-                    trace_id = get_current_trace_id()
-                    exemplar = {"trace_id": trace_id} if trace_id else None
-                    BATCH_PROCESSING_TIME.observe(batch_duration, exemplar=exemplar)
-
-                    # Record inference metrics
                     total_tokens = 0
-                    for result in results:
-                        if result.get("ttft", 0) > 0:
-                            TTFT.observe(result["ttft"])
-                            self.total_ttft += result["ttft"]
-                        if result.get("tpot", 0) > 0:
-                            TPOT.observe(result["tpot"])
-                            self.total_tpot += result["tpot"]
-                            self.total_inference_samples += 1
-                        tokens = result.get("total_tokens", 0)
-                        TOKENS_GENERATED.inc(tokens)
-                        total_tokens += tokens
+                    for (temperature, top_p, max_tokens), cache_keys in params_groups.items():
+                        prompts_to_infer = [unique_prompts[k][0].prompt for k in cache_keys]
+
+                        group_start = time.perf_counter()
+                        results = await self._run_batch_inference(
+                            prompts_to_infer, max_tokens, temperature, top_p
+                        )
+                        group_duration = time.perf_counter() - group_start
+
+                        # Exemplar for metric-trace correlation
+                        trace_id = get_current_trace_id()
+                        exemplar = {"trace_id": trace_id} if trace_id else None
+                        BATCH_PROCESSING_TIME.observe(group_duration, exemplar=exemplar)
+
+                        for cache_key, result in zip(cache_keys, results):
+                            if result.get("ttft", 0) > 0:
+                                TTFT.observe(result["ttft"])
+                                self.total_ttft += result["ttft"]
+                            if result.get("tpot", 0) > 0:
+                                TPOT.observe(result["tpot"])
+                                self.total_tpot += result["tpot"]
+                                self.total_inference_samples += 1
+                            tokens = result.get("total_tokens", 0)
+                            TOKENS_GENERATED.inc(tokens)
+                            total_tokens += tokens
+
+                            # Store in cache and distribute to all requests
+                            # sharing this cache_key.
+                            await self.cache.put(cache_key, result)
+                            for req in unique_prompts[cache_key]:
+                                if not req.future.done():
+                                    req.future.set_result(result)
 
                     logger.info(
                         "Batch inference completed",
                         extra={"extra_data": {
                             "batch_id": self.total_batches,
-                            "duration_s": round(batch_duration, 3),
-                            "prompts": len(prompts_to_infer),
+                            "prompts": len(unique_prompts),
+                            "param_groups": len(params_groups),
                             "tokens": total_tokens
                         }}
                     )
-
-                    # Distribute results to waiting requests and cache them
-                    for (cache_key, reqs), result in zip(unique_prompts.items(), results):
-                        # Store in cache
-                        await self.cache.put(cache_key, result)
-                        # Distribute to all requests with this cache_key
-                        for req in reqs:
-                            if not req.future.done():
-                                req.future.set_result(result)
 
                 except Exception as e:
                     span.set_attribute("error", True)

--- a/vgate/cache.py
+++ b/vgate/cache.py
@@ -56,7 +56,9 @@ class ResultCache:
         return hashlib.sha256(data.encode()).hexdigest()[:16]
 
     async def get(self, key: str) -> Optional[Dict]:
-        """Get a value from the cache. Returns None if not found."""
+        """Get a value from the cache. Returns None if not found or if caching is disabled."""
+        if not self.config.enabled:
+            return None
         with tracer.start_as_current_span("cache.get") as span:
             span.set_attribute("cache_key", key[:8])
             async with self._lock:
@@ -72,7 +74,9 @@ class ResultCache:
                 return None
 
     async def put(self, key: str, value: Dict) -> None:
-        """Put a value in the cache, evicting oldest if at capacity."""
+        """Put a value in the cache, evicting oldest if at capacity. No-op if caching is disabled."""
+        if not self.config.enabled:
+            return
         with tracer.start_as_current_span("cache.put") as span:
             span.set_attribute("cache_key", key[:8])
             evicted = False


### PR DESCRIPTION
## Summary

Fixes the semantics of the main request path per ROADMAP.md Phase 0 ("fix correctness and measurement first, before expanding the architecture").

- **`ResultCache.get/put` now respects `cache.enabled`.** The config flag was previously read nowhere; the cache stayed active regardless of the setting.
- **Fixed sampling-params mixing in `RequestBatcher._process_batch`.** It now groups deduplicated requests by `(temperature, top_p, max_tokens)` and dispatches one backend call per group, instead of silently applying only the first group's params to every prompt in the batch. Concurrent requests with different temperature/top_p landing in the same batch used to get the wrong params applied.
- **`max_batch_size` is now an enforced cap.** `_process_batch` used to drain the *entire* queue regardless of this setting (only using it as a trigger threshold) — confirmed on real GPU hardware in #23's baseline report. It now drains at most `max_batch_size` per call, and `stop()` loops until the queue is fully drained so a burst larger than one batch can't strand unresolved requests on shutdown.
- **`RequestBatcher.submit()` now takes an optional `timeout`** and cleans up the queue entry on both timeout and caller-side cancellation instead of leaking a dead entry.
- **`ChatCompletionRequest.messages` is now `list[ChatMessage]`** instead of a bare, unvalidated `list` — a malformed message previously crashed as an unhandled 500 instead of returning a clean 422.
- **Adds `.github/workflows/tests.yml`** running the dry-run server suite and the client SDK suite on push/PR to `main`.
- **Restores some documentation** (embeddings-mock note, `docs/` index links, micro-batching terminology) that existed in the working tree before #23 but was accidentally dropped while separating that PR's diff from unrelated pre-existing edits — my mistake, caught and fixed here.

## Test plan
- [x] `PYTHONPATH=. VGATE_DRY_RUN=true pytest tests/ -v` — 146 passed
- [x] `pytest vgate-client/tests/ -v` — 48 passed
- [x] Every new behavior verified to have a test that **fails against the prior code**: queue-time monotonic clock, sampling-params mixing, `max_batch_size` cap, timeout/cancellation queue cleanup, malformed-message validation
- [x] New CI workflow mirrors these exact commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)