### PR TITLE
Fix CI: install httpx/httpx2 test dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install pytest pytest-asyncio
+          pip install pytest pytest-asyncio httpx httpx2
 
       - name: Run tests (dry-run mode, no GPU)
         env:

--- a/README.md
+++ b/README.md
@@ -451,8 +451,9 @@ V-Gate/
 ### Running Tests
 
 ```bash
-# Install test dependencies
-pip install pytest pytest-asyncio
+# Install test dependencies (httpx2 is required by FastAPI's TestClient;
+# httpx is used directly by some tests for ASGI-transport requests)
+pip install pytest pytest-asyncio httpx httpx2
 
 # Run all tests
 PYTHONPATH=. VGATE_DRY_RUN=true pytest tests/ -v


### PR DESCRIPTION
## Summary
PR #25's CI run failed at test collection: `fastapi.testclient.TestClient` requires `httpx2` on the resolved starlette version (1.3.1), and `test_benchmark.py`/`test_chat_completions.py` import `httpx` directly for ASGI-transport requests. Neither was ever installed in `.github/workflows/tests.yml` or documented in the README's test setup — this worked in my local dev venv only by accident, because an earlier unrelated `pip install` had left both packages present.

- `.github/workflows/tests.yml`: install `httpx httpx2` alongside `pytest pytest-asyncio`.
- `README.md`: same addition to the documented "Install test dependencies" step, so following the docs from scratch actually works.

## Test plan
- [x] Reproduced the failure in a fresh throwaway venv with only `requirements.txt` + `pytest`/`pytest-asyncio` installed (matches the failing CI run exactly)
- [x] Same clean venv passes 146/146 once `httpx` and `httpx2` are added
- [x] `gh run list` shows the PR #25 CI run as `failure` for this exact reason (test collection error, not a real test failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)