### PR TITLE
Phase 2 (1/N): streaming chat completions (SSE) for dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,21 @@ curl -X POST http://localhost:8000/v1/chat/completions \
   }'
 ```
 
+### Streaming Chat Completions
+
+```bash
+curl -N -X POST http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen2.5-1.5B-Instruct-AWQ",
+    "messages": [{"role": "user", "content": "What is 2+2?"}],
+    "max_tokens": 100,
+    "stream": true
+  }'
+```
+
+Returns OpenAI-style SSE delta chunks. **Currently dry-run only** — the vLLM/SGLang backends raise a clear error until their async engine streaming paths land (see [ROADMAP.md](ROADMAP.md) Phase 2); the streaming path also bypasses the batcher/cache for now (no dedup or admission control yet).
+
 ### Prometheus Metrics
 ```bash
 curl http://localhost:8000/metrics

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ V-Gate is currently an OpenAI-style LLM gateway with:
 
 Current gaps:
 
-- OpenAI API compatibility is still shallow; streaming is missing.
+- OpenAI API compatibility is still shallow. Streaming (`stream: true`, SSE) now works end-to-end for the dry-run backend only; vLLM/SGLang backends raise a clear `NotImplementedError` until their async engine paths land (Phase 2).
 - Current batching is static micro-batching, not true continuous batching. New requests cannot join an already-running decode batch.
 - The runtime is still a single gateway with a single local backend, not real multi-worker serving.
 - Benchmark tooling exists, but systematic benchmark reports and analysis are missing.
@@ -266,6 +266,12 @@ Expected outcome:
 ---
 
 ### Phase 2: Streaming And Engine-Native Continuous Batching
+
+**Status: in progress — task 1-5 dry-run slice done, tasks 6-9 not started.** `stream: true` is supported end-to-end for the dry-run backend: `POST /v1/chat/completions` returns real SSE (`curl -N` shows incremental chunks) with OpenAI-style delta chunks (role chunk, content chunks, final `finish_reason: stop`, `data: [DONE]`). `InferenceBackend.stream_generate()` is now part of the protocol; `VLLMBackend`/`SGLangBackend` implement it as an explicit `NotImplementedError` (not a silent no-op) until their async engine paths land.
+
+Known, intentional limitation of this slice: the streaming path in `main.py` (`_stream_chat_completion`) calls `engine.backend.stream_generate()` directly and bypasses `RequestBatcher` entirely — no cache lookup, no batch-level dedup, no admission control for streamed requests yet. That integration is task 9 below, which is blocked on the AsyncLLMEngine work (tasks 6-7) since a per-request async engine is what makes "submit independent requests, not sealed Python batches" possible in the first place.
+
+Not yet done: client SDK streaming (task 4), streaming-specific metrics (task 5 - only basic completion logging exists so far), the vLLM/SGLang async engine backend paths (tasks 6-8), and redefining `RequestBatcher` (task 9).
 
 Priority: high.
 

--- a/main.py
+++ b/main.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import Response
+from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel
 from contextlib import asynccontextmanager
 import asyncio
+import json
 import time
 import uuid
 
@@ -184,6 +185,7 @@ class ChatCompletionRequest(BaseModel):
     temperature: float = 0.7
     top_p: float = 0.9
     max_tokens: int = 256
+    stream: bool = False
 
 
 class EmbeddingRequest(BaseModel):
@@ -205,12 +207,78 @@ async def health_check():
     return {"status": "ok", "version": APP_VERSION}
 
 
+async def _stream_chat_completion(prompt: str, request: ChatCompletionRequest):
+    """
+    SSE generator for streaming chat completions.
+
+    NOTE: this bypasses RequestBatcher entirely — it calls
+    engine.backend.stream_generate() directly, so streaming requests get no
+    cache lookup, no batch-level deduplication, and no admission control yet.
+    RequestBatcher is still GPU-batch-oriented and can't hand a partial
+    result back mid-generation. Folding streaming into batcher-provided
+    dedup/admission is ROADMAP.md Phase 2 task 9, not done here.
+    """
+    completion_id = "chatcmpl-" + str(uuid.uuid4())[:8]
+    created = int(time.time())
+
+    def _chunk(delta: dict, finish_reason: str = None) -> str:
+        payload = {
+            "id": completion_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": request.model,
+            "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+        }
+        return f"data: {json.dumps(payload)}\n\n"
+
+    yield _chunk({"role": "assistant"})
+    try:
+        sampling_params = engine.backend.create_sampling_params(
+            temperature=request.temperature, top_p=request.top_p, max_tokens=request.max_tokens
+        )
+        num_tokens = 0
+        async for piece in engine.backend.stream_generate(prompt, sampling_params):
+            if piece.get("delta"):
+                yield _chunk({"content": piece["delta"]})
+            num_tokens = piece.get("num_tokens", num_tokens)
+        yield _chunk({}, finish_reason="stop")
+        app_logger.info(
+            "Streamed chat completion",
+            extra={"extra_data": {"completion_id": completion_id, "tokens": num_tokens}}
+        )
+    except Exception as e:
+        # The 200 OK + SSE headers are already flushed by this point, so an
+        # HTTP error status is no longer possible; surface the failure as an
+        # SSE error event instead (mirrors how OpenAI's API reports
+        # mid-stream failures).
+        app_logger.error(
+            "Streaming chat completion error",
+            extra={"extra_data": {
+                "completion_id": completion_id,
+                "error": str(e),
+                "error_type": type(e).__name__
+            }}
+        )
+        yield f"data: {json.dumps({'error': {'message': str(e), 'type': type(e).__name__}})}\n\n"
+    finally:
+        yield "data: [DONE]\n\n"
+
+
 @app.post("/v1/chat/completions", summary="Create Chat Completion")
 async def create_chat_completion(request: ChatCompletionRequest):
     """
     Generates a chat completion response from the specified model.
-    Requests are automatically batched for improved throughput.
+    Non-streaming requests are automatically batched for improved throughput.
+    Streaming requests (stream=true) bypass the batcher; see
+    _stream_chat_completion for why.
     """
+    if request.stream:
+        prompt = messages_to_prompt(request.messages)
+        return StreamingResponse(
+            _stream_chat_completion(prompt, request),
+            media_type="text/event-stream",
+        )
+
     try:
         # Convert messages to a single prompt string for the engine
         prompt = messages_to_prompt(request.messages)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -67,6 +67,31 @@ class TestDryRunBackend:
         backend = DryRunBackend()
         backend.shutdown()  # Should not raise
 
+    @pytest.mark.asyncio
+    async def test_stream_generate_yields_incremental_chunks(self):
+        backend = DryRunBackend()
+        params = backend.create_sampling_params(0.7, 0.9, 128)
+
+        chunks = [c async for c in backend.stream_generate("Hello world", params)]
+
+        assert len(chunks) > 1
+        assert all("delta" in c and "num_tokens" in c for c in chunks)
+        # num_tokens must be a strictly increasing running total
+        counts = [c["num_tokens"] for c in chunks]
+        assert counts == sorted(counts)
+        assert counts[-1] == len(chunks)
+        # Concatenating every delta reproduces the same text generate() returns
+        assert "".join(c["delta"] for c in chunks) == "[dry-run] echo: Hello world"
+
+    @pytest.mark.asyncio
+    async def test_stream_generate_respects_max_tokens(self):
+        backend = DryRunBackend()
+        params = backend.create_sampling_params(0.7, 0.9, 2)
+
+        chunks = [c async for c in backend.stream_generate("Hello world", params)]
+
+        assert len(chunks) == 2
+
 
 class TestBackendFactory:
     """Tests for the _create_backend factory function."""
@@ -182,6 +207,15 @@ class TestVLLMBackendNormalization:
         results = backend.generate(["test"], MagicMock())
         assert results[0]["metrics"] == {}
 
+    @pytest.mark.asyncio
+    async def test_stream_generate_not_implemented(self):
+        from vgate.backends.vllm_backend import VLLMBackend
+
+        backend = VLLMBackend()
+        with pytest.raises(NotImplementedError):
+            async for _ in backend.stream_generate("test", MagicMock()):
+                pass
+
 
 class TestSGLangBackendNormalization:
     """Test SGLangBackend output normalization with mocked SGLang internals."""
@@ -225,3 +259,12 @@ class TestSGLangBackendNormalization:
         # Should fallback to word-count estimation
         assert results[0]["num_tokens"] >= 1
         assert results[0]["token_ids"] == []
+
+    @pytest.mark.asyncio
+    async def test_stream_generate_not_implemented(self):
+        from vgate.backends.sglang_backend import SGLangBackend
+
+        backend = SGLangBackend()
+        with pytest.raises(NotImplementedError):
+            async for _ in backend.stream_generate("test", {}):
+                pass

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,98 @@
+# Copyright 2025 the V-Gate authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for POST /v1/chat/completions with stream=true (SSE).
+
+Streaming bypasses RequestBatcher and talks to engine.backend.stream_generate()
+directly (see main.py's _stream_chat_completion docstring) — this is a
+known, intentional MVP limitation, not something these tests should hide.
+"""
+
+import json
+
+import pytest
+
+from vgate.config import reset_config
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    reset_config()
+    yield
+    reset_config()
+
+
+async def _collect_sse_events(response):
+    events = []
+    async for line in response.aiter_lines():
+        if line.startswith("data: "):
+            events.append(line[len("data: "):])
+    return events
+
+
+class TestStreamingChatCompletions:
+    @pytest.mark.asyncio
+    async def test_stream_true_returns_sse_with_role_content_and_done(self):
+        from httpx import ASGITransport, AsyncClient
+        from main import app, lifespan
+
+        async with lifespan(app):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                async with client.stream("POST", "/v1/chat/completions", json={
+                    "model": "test-model",
+                    "messages": [{"role": "user", "content": "Hello streaming"}],
+                    "max_tokens": 10,
+                    "stream": True,
+                }) as response:
+                    assert response.status_code == 200
+                    assert "text/event-stream" in response.headers["content-type"]
+                    events = await _collect_sse_events(response)
+
+        assert events[-1] == "[DONE]"
+
+        chunks = [json.loads(e) for e in events[:-1]]
+        assert chunks[0]["choices"][0]["delta"] == {"role": "assistant"}
+
+        content_deltas = [
+            c["choices"][0]["delta"]["content"]
+            for c in chunks
+            if "content" in c["choices"][0]["delta"]
+        ]
+        assert len(content_deltas) > 0
+        assert "".join(content_deltas).strip() != ""
+
+        assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+        # Every chunk shares one completion id (a single logical response)
+        assert len({c["id"] for c in chunks}) == 1
+
+    @pytest.mark.asyncio
+    async def test_stream_false_is_unaffected(self):
+        """Default (stream omitted) must still return a plain JSON response,
+        not SSE — this is the Phase 0 non-streaming path, untouched."""
+        from httpx import ASGITransport, AsyncClient
+        from main import app, lifespan
+
+        async with lifespan(app):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post("/v1/chat/completions", json={
+                    "model": "test-model",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                })
+
+        assert response.status_code == 200
+        assert "application/json" in response.headers["content-type"]
+        assert "choices" in response.json()

--- a/vgate/backends/base.py
+++ b/vgate/backends/base.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import os
 import time
-from typing import Any, Dict, List, Protocol, runtime_checkable
+from typing import Any, AsyncIterator, Dict, List, Protocol, runtime_checkable
 
 from vgate.config import ModelConfig
 
@@ -45,6 +46,18 @@ class InferenceBackend(Protocol):
         self, prompts: List[str], sampling_params: Any
     ) -> List[Dict[str, Any]]: ...
 
+    def stream_generate(
+        self, prompt: str, sampling_params: Any
+    ) -> AsyncIterator[Dict[str, Any]]:
+        """
+        Stream a single prompt's completion token-by-token.
+
+        Yields dicts shaped {"delta": str, "num_tokens": int} where
+        num_tokens is the cumulative token count so far; the last yielded
+        chunk's num_tokens is the total for the request.
+        """
+        ...
+
     def shutdown(self) -> None: ...
 
 
@@ -72,6 +85,17 @@ class DryRunBackend:
                 "metrics": {},
             })
         return results
+
+    async def stream_generate(
+        self, prompt: str, sampling_params: Any
+    ) -> AsyncIterator[Dict[str, Any]]:
+        max_tokens = sampling_params.get("max_tokens", 8) if isinstance(sampling_params, dict) else 8
+        words = f"[dry-run] echo: {prompt[:80]}".split()
+        num_words = min(len(words), max_tokens) or 1
+        for i in range(num_words):
+            await asyncio.sleep(0.02)
+            delta = words[i] + (" " if i < num_words - 1 else "")
+            yield {"delta": delta, "num_tokens": i + 1}
 
     def shutdown(self) -> None:
         pass

--- a/vgate/backends/sglang_backend.py
+++ b/vgate/backends/sglang_backend.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import time
-from typing import Any, Dict, List
+from typing import Any, AsyncIterator, Dict, List
 
 from vgate.config import ModelConfig
 
@@ -70,6 +70,18 @@ class SGLangBackend:
                 "metrics": {"wall_time": wall_time / len(prompts)},
             })
         return results
+
+    async def stream_generate(
+        self, prompt: str, sampling_params: Any
+    ) -> AsyncIterator[Dict[str, Any]]:
+        # sgl.Engine.generate() above is the offline batch API; streaming
+        # needs async_generate(..., stream=True) (ROADMAP.md Phase 2, task 8),
+        # not yet wired in.
+        raise NotImplementedError(
+            "Streaming is not yet implemented for the sglang backend "
+            "(see ROADMAP.md Phase 2: async_generate backend path)."
+        )
+        yield  # pragma: no cover - unreachable, makes this an async generator
 
     def shutdown(self) -> None:
         if self.engine is not None:

--- a/vgate/backends/vllm_backend.py
+++ b/vgate/backends/vllm_backend.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List
+from typing import Any, AsyncIterator, Dict, List
 
 from vgate.config import ModelConfig
 
@@ -76,6 +76,18 @@ class VLLMBackend:
                 "metrics": metrics_dict,
             })
         return results
+
+    async def stream_generate(
+        self, prompt: str, sampling_params: Any
+    ) -> AsyncIterator[Dict[str, Any]]:
+        # The offline LLM() API used by generate() above has no per-token
+        # streaming interface; that requires AsyncLLMEngine (ROADMAP.md
+        # Phase 2, task 7), not yet wired in.
+        raise NotImplementedError(
+            "Streaming is not yet implemented for the vllm backend "
+            "(see ROADMAP.md Phase 2: AsyncLLMEngine backend path)."
+        )
+        yield  # pragma: no cover - unreachable, makes this an async generator
 
     def shutdown(self) -> None:
         self.llm = None


### PR DESCRIPTION
## Summary

First slice of ROADMAP.md Phase 2 (streaming + engine-native continuous batching): gets real SSE streaming working end-to-end for the dry-run backend, with the real backends explicitly stubbed rather than silently broken.

- `ChatCompletionRequest.stream: bool = False`.
- `POST /v1/chat/completions` returns `text/event-stream` when `stream=true`: role delta → content deltas → `finish_reason: stop` → `data: [DONE]`, matching OpenAI's chunk format.
- `InferenceBackend.stream_generate()` added to the protocol. `DryRunBackend` implements it for real (word-by-word, respects `max_tokens`). `VLLMBackend`/`SGLangBackend` raise `NotImplementedError` pointing at the ROADMAP tasks that will fill them in.

**Known, intentional limitation** (documented in code + ROADMAP): the streaming path bypasses `RequestBatcher` entirely and calls `engine.backend.stream_generate()` directly — no cache, no dedup, no admission control for streamed requests yet. `RequestBatcher` is still GPU-batch-oriented and can't hand back a partial result mid-generation; folding streaming into batcher-provided dedup/admission is task 9, which needs the AsyncLLMEngine work (tasks 6-7) first. Those, plus client SDK streaming and streaming-specific metrics, are follow-up PRs.

## Test plan
- [x] `PYTHONPATH=. VGATE_DRY_RUN=true pytest tests/ -v` — 152 passed
- [x] `pytest vgate-client/tests/ -v` — 48 passed (untouched, sanity check)
- [x] Manually verified with `curl -N` against a running dry-run server — real incremental SSE chunks, not buffered
- [x] Verified non-streaming (`stream` omitted) is unaffected: still plain JSON, still goes through the batcher
- [x] Verified `VLLMBackend`/`SGLangBackend.stream_generate()` raise `NotImplementedError` rather than silently no-op