### PR TITLE
Phase 2 (2/N): vLLM AsyncLLMEngine — real streaming + continuous batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ curl -N -X POST http://localhost:8000/v1/chat/completions \
   }'
 ```
 
-Returns OpenAI-style SSE delta chunks. **Currently dry-run only** — the vLLM/SGLang backends raise a clear error until their async engine streaming paths land (see [ROADMAP.md](ROADMAP.md) Phase 2); the streaming path also bypasses the batcher/cache for now (no dedup or admission control yet).
+Returns OpenAI-style SSE delta chunks. Works for the dry-run backend and real vLLM (`AsyncLLMEngine`, verified on GPU); SGLang still raises a clear error until its async engine streaming path lands (see [ROADMAP.md](ROADMAP.md) Phase 2). The streaming path also bypasses the batcher/cache for now (no dedup or admission control yet).
 
 ### Prometheus Metrics
 ```bash

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,8 +23,8 @@ V-Gate is currently an OpenAI-style LLM gateway with:
 
 Current gaps:
 
-- OpenAI API compatibility is still shallow. Streaming (`stream: true`, SSE) now works end-to-end for the dry-run backend only; vLLM/SGLang backends raise a clear `NotImplementedError` until their async engine paths land (Phase 2).
-- Current batching is static micro-batching, not true continuous batching. New requests cannot join an already-running decode batch.
+- OpenAI API compatibility is still shallow. Streaming (`stream: true`, SSE) now works end-to-end for the dry-run backend and real vLLM (verified on GPU); SGLang still raises a clear `NotImplementedError` until its async engine path lands (Phase 2 task 8).
+- `RequestBatcher` still forms a static, sealed Python-side batch per window (queue drain, `max_batch_size`/`max_wait_time_ms`) before handing prompts to the backend — new requests still can't join an already-formed batch at that layer. Below that layer, `VLLMBackend` now submits each prompt as an independent `AsyncLLMEngine.generate()` call, so vLLM's own scheduler does get to interleave/continuously-batch them at the GPU level even though the Python-side batch above it is still static. Full task 9 (redefine `RequestBatcher` as dedup/admission/fan-out, not batch construction) is not done.
 - The runtime is still a single gateway with a single local backend, not real multi-worker serving.
 - Benchmark tooling exists, but systematic benchmark reports and analysis are missing.
 - Cache is RAM-only. There is no persistent local disk cache layer, and cache value depends on process lifetime. This is an intentional, benchmark-gated decision (Phase 1.5), not an oversight — current traffic shows no L1 eviction pressure.
@@ -269,11 +269,13 @@ Expected outcome:
 
 ### Phase 2: Streaming And Engine-Native Continuous Batching
 
-**Status: in progress — task 1-5 dry-run slice done, tasks 6-9 not started.** `stream: true` is supported end-to-end for the dry-run backend: `POST /v1/chat/completions` returns real SSE (`curl -N` shows incremental chunks) with OpenAI-style delta chunks (role chunk, content chunks, final `finish_reason: stop`, `data: [DONE]`). `InferenceBackend.stream_generate()` is now part of the protocol; `VLLMBackend`/`SGLangBackend` implement it as an explicit `NotImplementedError` (not a silent no-op) until their async engine paths land.
+**Status: in progress — tasks 1-3, 6 done; task 5 partial; tasks 4, 8, 9 not started.** `stream: true` is supported end-to-end for both the dry-run backend and real vLLM: `POST /v1/chat/completions` returns real SSE (`curl -N` shows incremental chunks, verified against a live GPU) with OpenAI-style delta chunks.
 
-Known, intentional limitation of this slice: the streaming path in `main.py` (`_stream_chat_completion`) calls `engine.backend.stream_generate()` directly and bypasses `RequestBatcher` entirely — no cache lookup, no batch-level dedup, no admission control for streamed requests yet. That integration is task 9 below, which is blocked on the AsyncLLMEngine work (tasks 6-7) since a per-request async engine is what makes "submit independent requests, not sealed Python batches" possible in the first place.
+`VLLMBackend` now runs on `AsyncLLMEngine` instead of the offline `LLM()` class (task 6, done) — a single engine instance backs both `generate()` (the batch-shaped call `RequestBatcher` still uses) and `stream_generate()`, avoiding a second model load / GPU-memory-budget conflict. `generate()` bridges from its calling worker thread to the engine's owning event loop via `asyncio.run_coroutine_threadsafe`. A side effect worth noting: even the non-streaming path now submits each prompt as an independent `engine.generate()` call rather than one sealed `LLM.generate(list, ...)` call, so it already gets real continuous batching from vLLM's own scheduler — ahead of the full `RequestBatcher` redefinition in task 9. `SGLangBackend.stream_generate()` still raises `NotImplementedError` (task 8 not started).
 
-Not yet done: client SDK streaming (task 4), streaming-specific metrics (task 5 - only basic completion logging exists so far), the vLLM/SGLang async engine backend paths (tasks 6-8), and redefining `RequestBatcher` (task 9).
+Known, intentional limitation: the streaming path in `main.py` (`_stream_chat_completion`) calls `engine.backend.stream_generate()` directly and bypasses `RequestBatcher` entirely — no cache lookup, no batch-level dedup, no admission control for streamed requests yet. That integration is task 9, not started.
+
+Not yet done: client SDK streaming (task 4), streaming-specific metrics beyond basic completion logging (task 5), the SGLang async backend path (task 8), and redefining `RequestBatcher` (task 9).
 
 Priority: high.
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -16,6 +16,7 @@
 Tests for inference backend abstraction layer.
 """
 
+import asyncio
 import os
 from unittest.mock import MagicMock, patch
 
@@ -156,32 +157,52 @@ class TestModelConfigEngineType:
 
 
 class TestVLLMBackendNormalization:
-    """Test VLLMBackend output normalization with mocked vLLM internals."""
+    """
+    Test VLLMBackend output normalization with a mocked AsyncLLMEngine.
 
-    def test_generate_normalizes_output(self):
+    generate() blocks synchronously via run_coroutine_threadsafe against the
+    loop captured in backend._loop, so it must be called from a different
+    thread than that loop (exactly how RequestBatcher calls it, via
+    run_in_executor) — calling it directly from the test's own loop would
+    deadlock: the blocking future.result() would never yield control back
+    for that same loop to actually run the scheduled coroutine.
+    """
+
+    @staticmethod
+    def _make_output(text, token_ids, metrics=None, finished=True):
+        output = MagicMock()
+        output.finished = finished
+        output.outputs = [MagicMock()]
+        output.outputs[0].text = text
+        output.outputs[0].token_ids = token_ids
+        output.metrics = metrics
+        return output
+
+    @pytest.mark.asyncio
+    async def test_generate_normalizes_output(self):
         from vgate.backends.vllm_backend import VLLMBackend
 
         backend = VLLMBackend()
+        backend._loop = asyncio.get_running_loop()
 
-        # Create mock vLLM output
-        mock_output = MagicMock()
-        mock_output.outputs = [MagicMock()]
-        mock_output.outputs[0].text = "Generated text"
-        mock_output.outputs[0].token_ids = [1, 2, 3, 4, 5]
         # Field names/semantics match vllm.v1.metrics.stats.RequestStateStats:
         # first_token_latency is precomputed by vLLM; first_token_ts/last_token_ts
         # are monotonic engine-core timestamps (arrival_time is a separate
         # wall-clock frontend timestamp and is not used for these deltas).
-        mock_output.metrics = MagicMock()
-        mock_output.metrics.first_token_latency = 0.1
-        mock_output.metrics.first_token_ts = 1.1
-        mock_output.metrics.last_token_ts = 1.5
+        metrics = MagicMock(first_token_latency=0.1, first_token_ts=1.1, last_token_ts=1.5)
+        final_output = self._make_output("Generated text", [1, 2, 3, 4, 5], metrics=metrics)
 
-        mock_llm = MagicMock()
-        mock_llm.generate.return_value = [mock_output]
-        backend.llm = mock_llm
+        async def fake_generate(prompt, sampling_params, request_id):
+            yield final_output
 
-        results = backend.generate(["test prompt"], MagicMock())
+        mock_engine = MagicMock()
+        mock_engine.generate = fake_generate
+        backend.engine = mock_engine
+
+        results = await asyncio.get_running_loop().run_in_executor(
+            None, backend.generate, ["test prompt"], MagicMock()
+        )
+
         assert len(results) == 1
         assert results[0]["text"] == "Generated text"
         assert results[0]["num_tokens"] == 5
@@ -189,32 +210,80 @@ class TestVLLMBackendNormalization:
         assert abs(results[0]["metrics"]["ttft"] - 0.1) < 0.001
         assert abs(results[0]["metrics"]["gen_time"] - 0.4) < 0.001
 
-    def test_generate_without_metrics(self):
+    @pytest.mark.asyncio
+    async def test_generate_without_metrics(self):
         from vgate.backends.vllm_backend import VLLMBackend
 
         backend = VLLMBackend()
+        backend._loop = asyncio.get_running_loop()
 
-        mock_output = MagicMock()
-        mock_output.outputs = [MagicMock()]
-        mock_output.outputs[0].text = "No metrics text"
-        mock_output.outputs[0].token_ids = [1, 2, 3]
-        mock_output.metrics = None
+        final_output = self._make_output("No metrics text", [1, 2, 3], metrics=None)
 
-        mock_llm = MagicMock()
-        mock_llm.generate.return_value = [mock_output]
-        backend.llm = mock_llm
+        async def fake_generate(prompt, sampling_params, request_id):
+            yield final_output
 
-        results = backend.generate(["test"], MagicMock())
+        mock_engine = MagicMock()
+        mock_engine.generate = fake_generate
+        backend.engine = mock_engine
+
+        results = await asyncio.get_running_loop().run_in_executor(
+            None, backend.generate, ["test"], MagicMock()
+        )
         assert results[0]["metrics"] == {}
 
     @pytest.mark.asyncio
-    async def test_stream_generate_not_implemented(self):
+    async def test_generate_only_uses_finished_output(self):
+        """Intermediate (unfinished) decode-step outputs must be ignored;
+        only the finished one should produce the final text/token count."""
         from vgate.backends.vllm_backend import VLLMBackend
 
         backend = VLLMBackend()
-        with pytest.raises(NotImplementedError):
-            async for _ in backend.stream_generate("test", MagicMock()):
-                pass
+        backend._loop = asyncio.get_running_loop()
+
+        partial = self._make_output("Gen", [1], finished=False)
+        final_output = self._make_output("Generated text", [1, 2, 3, 4, 5], finished=True)
+
+        async def fake_generate(prompt, sampling_params, request_id):
+            yield partial
+            yield final_output
+
+        mock_engine = MagicMock()
+        mock_engine.generate = fake_generate
+        backend.engine = mock_engine
+
+        results = await asyncio.get_running_loop().run_in_executor(
+            None, backend.generate, ["test"], MagicMock()
+        )
+        assert results[0]["text"] == "Generated text"
+        assert results[0]["num_tokens"] == 5
+
+    @pytest.mark.asyncio
+    async def test_stream_generate_yields_incremental_deltas(self):
+        """stream_generate() must yield only the *new* text since the last
+        chunk (vLLM's outputs[0].text is cumulative), not the full text
+        repeated on every step."""
+        from vgate.backends.vllm_backend import VLLMBackend
+
+        backend = VLLMBackend()
+
+        steps = [
+            self._make_output("Hello", [1], finished=False),
+            self._make_output("Hello world", [1, 2], finished=False),
+            self._make_output("Hello world!", [1, 2, 3], finished=True),
+        ]
+
+        async def fake_generate(prompt, sampling_params, request_id):
+            for step in steps:
+                yield step
+
+        mock_engine = MagicMock()
+        mock_engine.generate = fake_generate
+        backend.engine = mock_engine
+
+        chunks = [c async for c in backend.stream_generate("prompt", MagicMock())]
+
+        assert [c["delta"] for c in chunks] == ["Hello", " world", "!"]
+        assert [c["num_tokens"] for c in chunks] == [1, 2, 3]
 
 
 class TestSGLangBackendNormalization:

--- a/vgate/backends/vllm_backend.py
+++ b/vgate/backends/vllm_backend.py
@@ -12,33 +12,71 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+import uuid
 from typing import Any, AsyncIterator, Dict, List
 
 from vgate.config import ModelConfig
 
 
+def _extract_metrics(output: Any) -> Dict[str, Any]:
+    metrics_dict: Dict[str, Any] = {}
+    metrics = output.metrics
+    if metrics:
+        # first_token_latency is precomputed by vLLM; first_token_ts/
+        # last_token_ts are monotonic engine-core timestamps, safe to
+        # subtract (unlike arrival_time, which is a wall-clock frontend
+        # timestamp from a different clock domain).
+        metrics_dict["ttft"] = metrics.first_token_latency
+        metrics_dict["gen_time"] = metrics.last_token_ts - metrics.first_token_ts
+    return metrics_dict
+
+
 class VLLMBackend:
-    """Inference backend using vLLM."""
+    """
+    Inference backend using vLLM's AsyncLLMEngine.
+
+    A single AsyncLLMEngine instance backs both generate() (the synchronous,
+    batch-shaped call used by RequestBatcher) and stream_generate() (used by
+    the SSE path). Using one shared engine — rather than a second offline
+    LLM() instance — avoids loading the model twice and fighting over the
+    same gpu_memory_utilization budget. It also means non-streaming requests
+    are submitted to vLLM as independent generate() calls rather than one
+    sealed Python-side batch, so they get real continuous batching from
+    vLLM's own scheduler for free, ahead of the full RequestBatcher
+    redefinition in ROADMAP.md Phase 2 task 9.
+    """
 
     def __init__(self):
-        self.llm = None
+        self.engine = None
+        self._loop: asyncio.AbstractEventLoop | None = None
 
     def load_model(self, model_config: ModelConfig) -> None:
-        from vllm import LLM
+        from vllm import AsyncLLMEngine
+        from vllm.engine.arg_utils import AsyncEngineArgs
 
-        print(f"Loading {model_config.model_id} with {model_config.quantization} quantization (vLLM)...")
-        self.llm = LLM(
+        # load_model() runs synchronously inside main.py's `lifespan`
+        # coroutine (via VGateEngine.__init__), so this is the main uvicorn
+        # loop. generate() below is called from a worker thread (batcher.py's
+        # run_in_executor) and needs this reference to safely hand async
+        # engine calls back to the loop that owns the engine.
+        self._loop = asyncio.get_event_loop()
+
+        print(f"Loading {model_config.model_id} with {model_config.quantization} quantization (vLLM AsyncLLMEngine)...")
+        engine_args = AsyncEngineArgs(
             model=model_config.model_id,
             quantization=model_config.quantization,
             gpu_memory_utilization=model_config.gpu_memory_utilization,
             max_model_len=model_config.max_model_len,
             enforce_eager=model_config.enforce_eager,
             trust_remote_code=model_config.trust_remote_code,
-            # LLM() defaults this to True (unlike EngineArgs), which leaves
-            # output.metrics as None for every request and silently zeroes
-            # out TTFT/TPOT.
+            # AsyncEngineArgs defaults this to False already, unlike the
+            # offline LLM() class — kept explicit as a guard against that
+            # default flipping again (see vllm_backend.py history: this bit
+            # us once, silently zeroing out TTFT/TPOT).
             disable_log_stats=False,
         )
+        self.engine = AsyncLLMEngine.from_engine_args(engine_args)
 
     def create_sampling_params(
         self, temperature: float, top_p: float, max_tokens: int
@@ -49,45 +87,56 @@ class VLLMBackend:
             temperature=temperature, top_p=top_p, max_tokens=max_tokens
         )
 
+    async def _agenerate_one(self, prompt: str, sampling_params: Any) -> Any:
+        request_id = str(uuid.uuid4())
+        final_output = None
+        async for output in self.engine.generate(prompt, sampling_params, request_id):
+            if output.finished:
+                final_output = output
+        return final_output
+
     def generate(
         self, prompts: List[str], sampling_params: Any
     ) -> List[Dict[str, Any]]:
-        outputs = self.llm.generate(prompts, sampling_params)
+        """
+        Synchronous, batch-shaped entry point for RequestBatcher. Runs on a
+        worker thread; bridges to the AsyncLLMEngine on the main loop via
+        run_coroutine_threadsafe so there is only ever one engine/CUDA
+        context, regardless of which thread calls this.
+        """
+        async def _run_all():
+            return await asyncio.gather(*[
+                self._agenerate_one(p, sampling_params) for p in prompts
+            ])
+
+        future = asyncio.run_coroutine_threadsafe(_run_all(), self._loop)
+        outputs = future.result()
+
         results = []
         for output in outputs:
             text = output.outputs[0].text
             token_ids = output.outputs[0].token_ids
-            num_tokens = len(token_ids)
-
-            metrics_dict = {}
-            metrics = output.metrics
-            if metrics:
-                # first_token_latency is precomputed by vLLM; first_token_ts/
-                # last_token_ts are monotonic engine-core timestamps, safe to
-                # subtract (unlike arrival_time, which is a wall-clock
-                # frontend timestamp from a different clock domain).
-                metrics_dict["ttft"] = metrics.first_token_latency
-                metrics_dict["gen_time"] = metrics.last_token_ts - metrics.first_token_ts
-
             results.append({
                 "text": text,
                 "token_ids": list(token_ids),
-                "num_tokens": num_tokens,
-                "metrics": metrics_dict,
+                "num_tokens": len(token_ids),
+                "metrics": _extract_metrics(output),
             })
         return results
 
     async def stream_generate(
         self, prompt: str, sampling_params: Any
     ) -> AsyncIterator[Dict[str, Any]]:
-        # The offline LLM() API used by generate() above has no per-token
-        # streaming interface; that requires AsyncLLMEngine (ROADMAP.md
-        # Phase 2, task 7), not yet wired in.
-        raise NotImplementedError(
-            "Streaming is not yet implemented for the vllm backend "
-            "(see ROADMAP.md Phase 2: AsyncLLMEngine backend path)."
-        )
-        yield  # pragma: no cover - unreachable, makes this an async generator
+        """Runs directly on the caller's loop (main.py's SSE path is itself
+        async on the main loop), so no thread-bridging is needed here."""
+        request_id = str(uuid.uuid4())
+        prev_text_len = 0
+        async for output in self.engine.generate(prompt, sampling_params, request_id):
+            text = output.outputs[0].text
+            delta = text[prev_text_len:]
+            prev_text_len = len(text)
+            if delta:
+                yield {"delta": delta, "num_tokens": len(output.outputs[0].token_ids)}
 
     def shutdown(self) -> None:
-        self.llm = None
+        self.engine = None


### PR DESCRIPTION
## Summary

Second slice of ROADMAP.md Phase 2 (task 6): replaces `VLLMBackend`'s offline `LLM()` class with `AsyncLLMEngine`, so real vLLM gets working streaming and, as a side effect, real continuous batching on the non-streaming path too.

- One `AsyncLLMEngine` instance backs both `generate()` (the batch-shaped call `RequestBatcher` uses) and `stream_generate()` (SSE) — deliberately not two separate engines, since two would double the model load and fight over `gpu_memory_utilization` (confirmed this is a real constraint on 6GB VRAM while testing).
- `generate()` is called synchronously from a worker thread (via `RequestBatcher`'s `run_in_executor`), so it bridges to the engine's owning event loop with `asyncio.run_coroutine_threadsafe` rather than trying to drive the async engine from a thread that doesn't own it.
- Side effect: `generate()` now submits each prompt as an independent `engine.generate()` call instead of one sealed `LLM.generate(list, ...)` call, so even non-streaming requests get real continuous batching from vLLM's scheduler — ahead of the full `RequestBatcher` redefinition (task 9, still not done; the streaming path still bypasses the batcher entirely, as noted in the previous PR).

## Test plan
- [x] `PYTHONPATH=. VGATE_DRY_RUN=true pytest tests/ -v` — 153 passed
- [x] `pytest vgate-client/tests/ -v` — 48 passed (untouched, sanity check)
- [x] **Real GPU** (RTX 3060 Laptop, `Qwen2.5-1.5B-Instruct-AWQ`): non-streaming `/v1/chat/completions` still returns correct results
- [x] **Real GPU**: streaming (`curl -N`) shows genuine incremental SSE, token-by-token, not buffered — verified against a live counting-prompt response
- [x] **Real GPU**: server shuts down and releases GPU memory cleanly (checked `nvidia-smi` + no orphaned `EngineCore` process after teardown)
- [x] Unit tests updated to mock `AsyncLLMEngine` instead of the old offline `LLM`; added a test proving `generate()`'s thread-bridge doesn't deadlock, a test that only the *finished* engine output is used (not intermediate decode steps), and a `stream_generate` test proving deltas are the new text since the last chunk (vLLM's `outputs[0].text` is cumulative, not incremental — an easy bug to introduce)