### PR TITLE
Phase 2 (3/N): client SDK streaming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,37 @@ async with AsyncVGate(base_url="http://localhost:8000", api_key="sk-...") as cli
     )
 ```
 
+Streaming is available on both clients as `chat.stream(...)`, yielding OpenAI-style `ChatCompletionChunk` objects (`chunk.choices[0].delta.content`):
+
+```python
+from vgate_client import VGate
+
+client = VGate(base_url="http://localhost:8000")
+for chunk in client.chat.stream(
+    model="Qwen/Qwen2.5-1.5B-Instruct-AWQ",
+    messages=[{"role": "user", "content": "What is 2+2?"}],
+    max_tokens=100,
+):
+    if chunk.choices[0].delta.content:
+        print(chunk.choices[0].delta.content, end="", flush=True)
+client.close()
+```
+
+```python
+from vgate_client import AsyncVGate
+
+async with AsyncVGate(base_url="http://localhost:8000") as client:
+    async for chunk in client.chat.stream(
+        model="Qwen/Qwen2.5-1.5B-Instruct-AWQ",
+        messages=[{"role": "user", "content": "What is 2+2?"}],
+        max_tokens=100,
+    ):
+        if chunk.choices[0].delta.content:
+            print(chunk.choices[0].delta.content, end="", flush=True)
+```
+
+A failure mid-stream (a `data: {"error": ...}` event from the server, or a dropped connection) raises immediately — `chat.stream()` never retries once tokens have already been yielded, since a retry would duplicate text the caller already received.
+
 ---
 
 ## Benchmark

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ async with AsyncVGate(base_url="http://localhost:8000") as client:
             print(chunk.choices[0].delta.content, end="", flush=True)
 ```
 
-A failure mid-stream (a `data: {"error": ...}` event from the server, or a dropped connection) raises immediately — `chat.stream()` never retries once tokens have already been yielded, since a retry would duplicate text the caller already received.
+A failure mid-stream (a `data: {"error": ...}` event from the server, or a dropped connection) raises immediately — `chat.stream()` never retries once tokens have already been yielded, since a retry would duplicate text the caller already received. This includes the connection ending without a `data: [DONE]` event: that's treated as a broken stream (`ServerError`), not a clean completion. `chat.stream(...)` also works as a context manager (`with client.chat.stream(...) as stream:` / `async with ...`) so stopping iteration early — e.g. `break` — still closes the underlying connection deterministically instead of leaving it open until GC.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -269,13 +269,15 @@ Expected outcome:
 
 ### Phase 2: Streaming And Engine-Native Continuous Batching
 
-**Status: in progress — tasks 1-3, 6 done; task 5 partial; tasks 4, 8, 9 not started.** `stream: true` is supported end-to-end for both the dry-run backend and real vLLM: `POST /v1/chat/completions` returns real SSE (`curl -N` shows incremental chunks, verified against a live GPU) with OpenAI-style delta chunks.
+**Status: in progress — tasks 1-4, 6 done; task 5 partial; tasks 8, 9 not started.** `stream: true` is supported end-to-end for both the dry-run backend and real vLLM: `POST /v1/chat/completions` returns real SSE (`curl -N` shows incremental chunks, verified against a live GPU) with OpenAI-style delta chunks.
+
+Task 4 (client SDK streaming) is done: both `VGate.chat.stream(...)` and `AsyncVGate.chat.stream(...)` consume the server's SSE response and yield OpenAI-shaped `ChatCompletionChunk` objects (`chunk.choices[0].delta.content`), verified against a live dry-run server for both the sync and async paths. Mid-stream failures (a `data: {"error": ...}` event, or a dropped connection) raise immediately rather than being retried, since a retry after tokens have already been yielded would duplicate text.
 
 `VLLMBackend` now runs on `AsyncLLMEngine` instead of the offline `LLM()` class (task 6, done) — a single engine instance backs both `generate()` (the batch-shaped call `RequestBatcher` still uses) and `stream_generate()`, avoiding a second model load / GPU-memory-budget conflict. `generate()` bridges from its calling worker thread to the engine's owning event loop via `asyncio.run_coroutine_threadsafe`. A side effect worth noting: even the non-streaming path now submits each prompt as an independent `engine.generate()` call rather than one sealed `LLM.generate(list, ...)` call, so it already gets real continuous batching from vLLM's own scheduler — ahead of the full `RequestBatcher` redefinition in task 9. `SGLangBackend.stream_generate()` still raises `NotImplementedError` (task 8 not started).
 
 Known, intentional limitation: the streaming path in `main.py` (`_stream_chat_completion`) calls `engine.backend.stream_generate()` directly and bypasses `RequestBatcher` entirely — no cache lookup, no batch-level dedup, no admission control for streamed requests yet. That integration is task 9, not started.
 
-Not yet done: client SDK streaming (task 4), streaming-specific metrics beyond basic completion logging (task 5), the SGLang async backend path (task 8), and redefining `RequestBatcher` (task 9).
+Not yet done: streaming-specific metrics beyond basic completion logging (task 5), the SGLang async backend path (task 8), and redefining `RequestBatcher` (task 9).
 
 Priority: high.
 

--- a/vgate-client/tests/test_models.py
+++ b/vgate-client/tests/test_models.py
@@ -16,6 +16,7 @@
 
 from vgate_client.models import (
     ChatCompletion,
+    ChatCompletionChunk,
     ChatCompletionRequest,
     ChatMessage,
     EmbeddingRequest,
@@ -36,6 +37,7 @@ class TestChatCompletionRequest:
         assert req.temperature == 0.7
         assert req.top_p == 0.9
         assert req.max_tokens == 256
+        assert req.stream is False
 
     def test_custom_params(self):
         req = ChatCompletionRequest(
@@ -73,6 +75,41 @@ class TestChatCompletion:
             choices=[],
         )
         assert resp.usage.prompt_tokens == 0
+
+
+class TestChatCompletionChunk:
+    def test_parse_role_chunk(self):
+        chunk = ChatCompletionChunk.model_validate({
+            "id": "chatcmpl-1",
+            "object": "chat.completion.chunk",
+            "created": 1700000000,
+            "model": "m",
+            "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
+        })
+        assert chunk.choices[0].delta.role == "assistant"
+        assert chunk.choices[0].delta.content is None
+        assert chunk.choices[0].finish_reason is None
+
+    def test_parse_content_chunk(self):
+        chunk = ChatCompletionChunk.model_validate({
+            "id": "chatcmpl-1",
+            "created": 1700000000,
+            "model": "m",
+            "choices": [{"index": 0, "delta": {"content": "Hi"}, "finish_reason": None}],
+        })
+        assert chunk.choices[0].delta.content == "Hi"
+        assert chunk.object == "chat.completion.chunk"
+
+    def test_parse_finish_chunk(self):
+        chunk = ChatCompletionChunk.model_validate({
+            "id": "chatcmpl-1",
+            "created": 1700000000,
+            "model": "m",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+        })
+        assert chunk.choices[0].finish_reason == "stop"
+        assert chunk.choices[0].delta.content is None
+        assert chunk.choices[0].delta.role is None
 
 
 class TestEmbeddingResponse:

--- a/vgate-client/tests/test_streaming.py
+++ b/vgate-client/tests/test_streaming.py
@@ -44,6 +44,14 @@ _NORMAL_LINES = [
     "data: [DONE]",
 ]
 
+_NO_DONE_LINES = [
+    'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"m",'
+    '"choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+    'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"m",'
+    '"choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}',
+    # connection drops here — no "data: [DONE]" line follows
+]
+
 _ERROR_MID_STREAM_LINES = [
     'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"m",'
     '"choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
@@ -234,6 +242,68 @@ class TestSyncStream:
             list(client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}]))
         client.close()
 
+    def test_missing_done_raises_server_error(self, monkeypatch):
+        """A connection that ends without ever sending `data: [DONE]` must
+        not look like a clean completion — it should raise, not silently
+        stop yielding."""
+        client = VGate()
+        monkeypatch.setattr(
+            client._http, "stream", lambda *a, **kw: _FakeSyncStreamCM(lines=_NO_DONE_LINES)
+        )
+
+        chunks = []
+        with pytest.raises(ServerError, match=r"\[DONE\]"):
+            for chunk in client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}]):
+                chunks.append(chunk)
+
+        # The chunks that did arrive before the drop are still delivered.
+        assert len(chunks) == 2
+        client.close()
+
+    def test_context_manager_closes_connection_on_early_break(self, monkeypatch):
+        """Stopping iteration early (via `break` inside a `with` block) must
+        still close the underlying SSE connection deterministically."""
+        client = VGate()
+        holder = {}
+
+        def fake_stream(*a, **kw):
+            cm = _FakeSyncStreamCM(lines=_NORMAL_LINES)
+            holder["cm"] = cm
+            return cm
+
+        monkeypatch.setattr(client._http, "stream", fake_stream)
+
+        seen = []
+        with client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}]) as stream:
+            for chunk in stream:
+                seen.append(chunk)
+                if chunk.choices[0].delta.role == "assistant":
+                    break
+
+        assert len(seen) == 1
+        assert holder["cm"].exited is True
+        client.close()
+
+    def test_explicit_close_without_with_closes_connection(self, monkeypatch):
+        """Even without the context-manager form, calling .close() directly
+        on the returned stream must close the underlying connection."""
+        client = VGate()
+        holder = {}
+
+        def fake_stream(*a, **kw):
+            cm = _FakeSyncStreamCM(lines=_NORMAL_LINES)
+            holder["cm"] = cm
+            return cm
+
+        monkeypatch.setattr(client._http, "stream", fake_stream)
+
+        stream = client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}])
+        next(stream)
+        stream.close()
+
+        assert holder["cm"].exited is True
+        client.close()
+
 
 # ── Async ────────────────────────────────────────────────────────────────────
 
@@ -348,4 +418,68 @@ class TestAsyncStream:
         with pytest.raises(ConnectionError):
             async for _ in client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}]):
                 pass
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_missing_done_raises_server_error(self, monkeypatch):
+        """A connection that ends without ever sending `data: [DONE]` must
+        not look like a clean completion — it should raise, not silently
+        stop yielding."""
+        client = AsyncVGate()
+        monkeypatch.setattr(
+            client._http, "stream", lambda *a, **kw: _FakeAsyncStreamCM(lines=_NO_DONE_LINES)
+        )
+
+        chunks = []
+        with pytest.raises(ServerError, match=r"\[DONE\]"):
+            async for chunk in client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}]):
+                chunks.append(chunk)
+
+        assert len(chunks) == 2
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_context_manager_closes_connection_on_early_break(self, monkeypatch):
+        """Stopping iteration early (via `break` inside an `async with` block)
+        must still close the underlying SSE connection deterministically."""
+        client = AsyncVGate()
+        holder = {}
+
+        def fake_stream(*a, **kw):
+            cm = _FakeAsyncStreamCM(lines=_NORMAL_LINES)
+            holder["cm"] = cm
+            return cm
+
+        monkeypatch.setattr(client._http, "stream", fake_stream)
+
+        seen = []
+        async with client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}]) as stream:
+            async for chunk in stream:
+                seen.append(chunk)
+                if chunk.choices[0].delta.role == "assistant":
+                    break
+
+        assert len(seen) == 1
+        assert holder["cm"].exited is True
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_explicit_close_without_with_closes_connection(self, monkeypatch):
+        """Even without the context-manager form, calling .aclose() directly
+        on the returned stream must close the underlying connection."""
+        client = AsyncVGate()
+        holder = {}
+
+        def fake_stream(*a, **kw):
+            cm = _FakeAsyncStreamCM(lines=_NORMAL_LINES)
+            holder["cm"] = cm
+            return cm
+
+        monkeypatch.setattr(client._http, "stream", fake_stream)
+
+        stream = client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}])
+        await stream.__anext__()
+        await stream.aclose()
+
+        assert holder["cm"].exited is True
         await client.close()

--- a/vgate-client/tests/test_streaming.py
+++ b/vgate-client/tests/test_streaming.py
@@ -1,0 +1,351 @@
+# Copyright 2025 the V-Gate authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for client.chat.stream() (sync and async SSE consumption)."""
+
+import json
+
+import httpx
+import pytest
+
+from vgate_client import AsyncVGate, VGate
+from vgate_client.exceptions import (
+    AuthenticationError,
+    ConnectionError,
+    RateLimitError,
+    ServerError,
+    VGateError,
+)
+from vgate_client.models import ChatCompletionChunk
+
+_NORMAL_LINES = [
+    'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"m",'
+    '"choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+    "",
+    ": this is an SSE comment, not a data line",
+    "event: message",
+    'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"m",'
+    '"choices":[{"index":0,"delta":{"content":"Hel"},"finish_reason":null}]}',
+    'data:{"id":"c1","object":"chat.completion.chunk","created":1,"model":"m",'
+    '"choices":[{"index":0,"delta":{"content":"lo"},"finish_reason":null}]}',
+    'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"m",'
+    '"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+    "data: [DONE]",
+]
+
+_ERROR_MID_STREAM_LINES = [
+    'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"m",'
+    '"choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+    'data: {"error": {"message": "backend exploded", "type": "RuntimeError"}}',
+]
+
+
+def _build_response(status_code, content_type, json_body):
+    headers = {}
+    if content_type is not None:
+        headers["content-type"] = content_type
+    return httpx.Response(
+        status_code=status_code,
+        headers=headers,
+        content=json.dumps(json_body or {}).encode(),
+        request=httpx.Request("POST", "http://test/"),
+    )
+
+
+class _FakeSyncStreamCM:
+    """Stand-in for the context manager httpx.Client.stream() returns."""
+
+    def __init__(self, lines=None, status_code=200, content_type="text/event-stream", json_body=None):
+        self.lines = lines or []
+        self.status_code = status_code
+        self.content_type = content_type
+        self.json_body = json_body
+        self.entered = False
+        self.exited = False
+
+    def __enter__(self):
+        self.entered = True
+        response = _build_response(self.status_code, self.content_type, self.json_body)
+        response.iter_lines = lambda: iter(self.lines)
+        return response
+
+    def __exit__(self, *exc_info):
+        self.exited = True
+        return False
+
+
+class _FakeAsyncStreamCM:
+    """Stand-in for the async context manager httpx.AsyncClient.stream() returns.
+
+    AsyncClient.stream() itself is a plain (non-async) method that returns an
+    async context manager, so the monkeypatched replacement must also be a
+    plain function/lambda — an `async def` here would need an extra await
+    the real client code never performs.
+    """
+
+    def __init__(self, lines=None, status_code=200, content_type="text/event-stream", json_body=None):
+        self.lines = lines or []
+        self.status_code = status_code
+        self.content_type = content_type
+        self.json_body = json_body
+        self.entered = False
+        self.exited = False
+
+    async def __aenter__(self):
+        self.entered = True
+        response = _build_response(self.status_code, self.content_type, self.json_body)
+
+        async def _aiter_lines():
+            for line in self.lines:
+                yield line
+
+        response.aiter_lines = _aiter_lines
+        return response
+
+    async def __aexit__(self, *exc_info):
+        self.exited = True
+        return False
+
+
+# ── Sync ─────────────────────────────────────────────────────────────────────
+
+
+class TestSyncStream:
+    def test_yields_role_content_and_finish_chunks(self, monkeypatch):
+        client = VGate()
+        monkeypatch.setattr(
+            client._http, "stream", lambda *a, **kw: _FakeSyncStreamCM(lines=_NORMAL_LINES)
+        )
+
+        chunks = list(
+            client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}])
+        )
+
+        assert all(isinstance(c, ChatCompletionChunk) for c in chunks)
+        assert chunks[0].choices[0].delta.role == "assistant"
+        content = "".join(
+            c.choices[0].delta.content for c in chunks if c.choices[0].delta.content
+        )
+        assert content == "Hello"
+        assert chunks[-1].choices[0].finish_reason == "stop"
+        client.close()
+
+    def test_request_body_sets_stream_true(self, monkeypatch):
+        client = VGate()
+        captured = {}
+
+        def fake_stream(method, path, **kw):
+            captured["json"] = kw.get("json")
+            return _FakeSyncStreamCM(lines=_NORMAL_LINES)
+
+        monkeypatch.setattr(client._http, "stream", fake_stream)
+
+        list(client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}]))
+
+        assert captured["json"]["stream"] is True
+        client.close()
+
+    def test_context_manager_exits_on_normal_completion(self, monkeypatch):
+        client = VGate()
+        holder = {}
+
+        def fake_stream(*a, **kw):
+            cm = _FakeSyncStreamCM(lines=_NORMAL_LINES)
+            holder["cm"] = cm
+            return cm
+
+        monkeypatch.setattr(client._http, "stream", fake_stream)
+
+        list(client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}]))
+
+        assert holder["cm"].entered is True
+        assert holder["cm"].exited is True
+        client.close()
+
+    def test_mid_stream_error_event_raises_server_error(self, monkeypatch):
+        client = VGate()
+        holder = {}
+
+        def fake_stream(*a, **kw):
+            cm = _FakeSyncStreamCM(lines=_ERROR_MID_STREAM_LINES)
+            holder["cm"] = cm
+            return cm
+
+        monkeypatch.setattr(client._http, "stream", fake_stream)
+
+        with pytest.raises(ServerError, match="backend exploded"):
+            list(client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}]))
+
+        assert holder["cm"].exited is True
+        client.close()
+
+    @pytest.mark.parametrize(
+        "status_code,exc_type",
+        [(401, AuthenticationError), (429, RateLimitError), (500, ServerError)],
+    )
+    def test_http_error_before_any_data_raises(self, monkeypatch, status_code, exc_type):
+        client = VGate(max_retries=0)
+        monkeypatch.setattr(
+            client._http,
+            "stream",
+            lambda *a, **kw: _FakeSyncStreamCM(
+                status_code=status_code,
+                content_type="application/json",
+                json_body={"detail": "boom"},
+            ),
+        )
+
+        with pytest.raises(exc_type):
+            list(client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}]))
+        client.close()
+
+    def test_unexpected_content_type_raises(self, monkeypatch):
+        client = VGate()
+        monkeypatch.setattr(
+            client._http,
+            "stream",
+            lambda *a, **kw: _FakeSyncStreamCM(content_type="application/json", json_body={}),
+        )
+
+        with pytest.raises(VGateError, match="text/event-stream"):
+            list(client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}]))
+        client.close()
+
+    def test_connection_error(self, monkeypatch):
+        client = VGate()
+
+        def raise_connect(*a, **kw):
+            raise httpx.ConnectError("Connection refused")
+
+        monkeypatch.setattr(client._http, "stream", raise_connect)
+
+        with pytest.raises(ConnectionError):
+            list(client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}]))
+        client.close()
+
+
+# ── Async ────────────────────────────────────────────────────────────────────
+
+
+class TestAsyncStream:
+    @pytest.mark.asyncio
+    async def test_yields_role_content_and_finish_chunks(self, monkeypatch):
+        client = AsyncVGate()
+        monkeypatch.setattr(
+            client._http, "stream", lambda *a, **kw: _FakeAsyncStreamCM(lines=_NORMAL_LINES)
+        )
+
+        chunks = [
+            c async for c in client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}])
+        ]
+
+        assert all(isinstance(c, ChatCompletionChunk) for c in chunks)
+        assert chunks[0].choices[0].delta.role == "assistant"
+        content = "".join(
+            c.choices[0].delta.content for c in chunks if c.choices[0].delta.content
+        )
+        assert content == "Hello"
+        assert chunks[-1].choices[0].finish_reason == "stop"
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_request_body_sets_stream_true(self, monkeypatch):
+        client = AsyncVGate()
+        captured = {}
+
+        def fake_stream(method, path, **kw):
+            captured["json"] = kw.get("json")
+            return _FakeAsyncStreamCM(lines=_NORMAL_LINES)
+
+        monkeypatch.setattr(client._http, "stream", fake_stream)
+
+        async for _ in client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}]):
+            pass
+
+        assert captured["json"]["stream"] is True
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_context_manager_exits_on_normal_completion(self, monkeypatch):
+        client = AsyncVGate()
+        holder = {}
+
+        def fake_stream(*a, **kw):
+            cm = _FakeAsyncStreamCM(lines=_NORMAL_LINES)
+            holder["cm"] = cm
+            return cm
+
+        monkeypatch.setattr(client._http, "stream", fake_stream)
+
+        async for _ in client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}]):
+            pass
+
+        assert holder["cm"].entered is True
+        assert holder["cm"].exited is True
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_error_event_raises_server_error(self, monkeypatch):
+        client = AsyncVGate()
+        holder = {}
+
+        def fake_stream(*a, **kw):
+            cm = _FakeAsyncStreamCM(lines=_ERROR_MID_STREAM_LINES)
+            holder["cm"] = cm
+            return cm
+
+        monkeypatch.setattr(client._http, "stream", fake_stream)
+
+        with pytest.raises(ServerError, match="backend exploded"):
+            async for _ in client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}]):
+                pass
+
+        assert holder["cm"].exited is True
+        await client.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "status_code,exc_type",
+        [(401, AuthenticationError), (429, RateLimitError), (500, ServerError)],
+    )
+    async def test_http_error_before_any_data_raises(self, monkeypatch, status_code, exc_type):
+        client = AsyncVGate(max_retries=0)
+        monkeypatch.setattr(
+            client._http,
+            "stream",
+            lambda *a, **kw: _FakeAsyncStreamCM(
+                status_code=status_code,
+                content_type="application/json",
+                json_body={"detail": "boom"},
+            ),
+        )
+
+        with pytest.raises(exc_type):
+            async for _ in client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}]):
+                pass
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self, monkeypatch):
+        client = AsyncVGate()
+
+        def raise_connect(*a, **kw):
+            raise httpx.ConnectError("Connection refused")
+
+        monkeypatch.setattr(client._http, "stream", raise_connect)
+
+        with pytest.raises(ConnectionError):
+            async for _ in client.chat.stream(model="m", messages=[{"role": "user", "content": "hi"}]):
+                pass
+        await client.close()

--- a/vgate-client/vgate_client/__init__.py
+++ b/vgate-client/vgate_client/__init__.py
@@ -45,6 +45,9 @@ from .exceptions import (
 )
 from .models import (
     ChatCompletion,
+    ChatCompletionChunk,
+    ChatCompletionChunkChoice,
+    ChatCompletionDelta,
     ChatMessage,
     Choice,
     EmbeddingData,
@@ -63,6 +66,9 @@ __all__ = [
     "AsyncVGate",
     # Response models
     "ChatCompletion",
+    "ChatCompletionChunk",
+    "ChatCompletionChunkChoice",
+    "ChatCompletionDelta",
     "Choice",
     "ResponseMessage",
     "EmbeddingResponse",

--- a/vgate-client/vgate_client/client.py
+++ b/vgate-client/vgate_client/client.py
@@ -16,8 +16,9 @@
 
 from __future__ import annotations
 
+import json
 import time
-from typing import Optional, Union
+from typing import AsyncIterator, Iterator, Optional, Union
 
 import httpx
 
@@ -30,6 +31,7 @@ from .exceptions import (
 )
 from .models import (
     ChatCompletion,
+    ChatCompletionChunk,
     ChatCompletionRequest,
     ChatMessage,
     EmbeddingRequest,
@@ -89,6 +91,41 @@ def _raise_for_status(response: httpx.Response) -> None:
     raise VGateError(detail, status_code=status, body=body)
 
 
+_STREAM_DONE = object()  # sentinel: the "data: [DONE]" line was reached
+
+
+def _parse_sse_line(line: str):
+    """Parse one SSE line.
+
+    Returns ``None`` for lines to skip (blank lines, comments, non-``data:``
+    fields), the ``_STREAM_DONE`` sentinel for ``data: [DONE]``, or a parsed
+    ``ChatCompletionChunk`` otherwise. Raises ``ServerError`` if the line
+    carries a mid-stream error event (see main.py's _stream_chat_completion,
+    which can emit `{"error": {...}}` after the 200 response is already
+    flushed).
+    """
+    if not line or not line.startswith("data:"):
+        return None
+    payload = line[len("data:"):].lstrip(" ")
+    if payload == "[DONE]":
+        return _STREAM_DONE
+    data = json.loads(payload)
+    if "error" in data:
+        err = data["error"]
+        raise ServerError(err.get("message", "stream error"), body=data)
+    return ChatCompletionChunk.model_validate(data)
+
+
+def _check_stream_content_type(response: httpx.Response) -> None:
+    content_type = response.headers.get("content-type", "")
+    if "text/event-stream" not in content_type:
+        raise VGateError(
+            f"Expected a text/event-stream response but got Content-Type: "
+            f"{content_type or '<missing>'}",
+            status_code=response.status_code,
+        )
+
+
 def _build_headers(api_key: Optional[str]) -> dict[str, str]:
     headers: dict[str, str] = {"Content-Type": "application/json"}
     if api_key:
@@ -135,6 +172,32 @@ class _SyncChat:
         )
         data = self._client._request("POST", "/v1/chat/completions", json=req.model_dump())
         return ChatCompletion.model_validate(data)
+
+    def stream(
+        self,
+        *,
+        model: str,
+        messages: list[dict[str, str]],
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        max_tokens: int = 256,
+    ) -> Iterator[ChatCompletionChunk]:
+        """Create a streaming chat completion.
+
+        Yields ``ChatCompletionChunk`` objects as they arrive over SSE. A
+        failure that happens after the stream has already started (mid-stream
+        error event, or the connection dropping) is not retried — retrying
+        would re-emit text the caller already received.
+        """
+        req = ChatCompletionRequest(
+            model=model,
+            messages=[ChatMessage(**m) for m in messages],
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+            stream=True,
+        )
+        return self._client._stream_chat(req)
 
 
 class _SyncEmbeddings:
@@ -187,6 +250,31 @@ class _AsyncChat:
         )
         data = await self._client._request("POST", "/v1/chat/completions", json=req.model_dump())
         return ChatCompletion.model_validate(data)
+
+    def stream(
+        self,
+        *,
+        model: str,
+        messages: list[dict[str, str]],
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        max_tokens: int = 256,
+    ) -> AsyncIterator[ChatCompletionChunk]:
+        """Create a streaming chat completion.
+
+        Not itself a coroutine — it returns an async generator immediately
+        so ``async for chunk in client.chat.stream(...)`` works without an
+        extra ``await``, mirroring ``httpx.AsyncClient.stream()``.
+        """
+        req = ChatCompletionRequest(
+            model=model,
+            messages=[ChatMessage(**m) for m in messages],
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+            stream=True,
+        )
+        return self._client._stream_chat(req)
 
 
 class _AsyncEmbeddings:
@@ -278,6 +366,26 @@ class VGate:
 
         # Should not reach here, but just in case
         raise last_exc or VGateError("Request failed after retries")
+
+    def _stream_chat(self, req: ChatCompletionRequest) -> Iterator[ChatCompletionChunk]:
+        """Open an SSE stream and yield parsed chunks. No retry: once bytes
+        have been yielded to the caller, retrying would duplicate text."""
+        try:
+            with self._http.stream(
+                "POST", "/v1/chat/completions", json=req.model_dump()
+            ) as response:
+                if not response.is_success:
+                    response.read()
+                    _raise_for_status(response)
+                _check_stream_content_type(response)
+                for line in response.iter_lines():
+                    parsed = _parse_sse_line(line)
+                    if parsed is _STREAM_DONE:
+                        return
+                    if parsed is not None:
+                        yield parsed
+        except httpx.ConnectError as exc:
+            raise ConnectionError(f"Cannot connect to {self.base_url}: {exc}") from exc
 
     # -- convenience endpoints --------------------------------------------
 
@@ -381,6 +489,26 @@ class AsyncVGate:
             _raise_for_status(response)
 
         raise VGateError("Request failed after retries")
+
+    async def _stream_chat(self, req: ChatCompletionRequest) -> AsyncIterator[ChatCompletionChunk]:
+        """Open an SSE stream and yield parsed chunks. No retry: once bytes
+        have been yielded to the caller, retrying would duplicate text."""
+        try:
+            async with self._http.stream(
+                "POST", "/v1/chat/completions", json=req.model_dump()
+            ) as response:
+                if not response.is_success:
+                    await response.aread()
+                    _raise_for_status(response)
+                _check_stream_content_type(response)
+                async for line in response.aiter_lines():
+                    parsed = _parse_sse_line(line)
+                    if parsed is _STREAM_DONE:
+                        return
+                    if parsed is not None:
+                        yield parsed
+        except httpx.ConnectError as exc:
+            raise ConnectionError(f"Cannot connect to {self.base_url}: {exc}") from exc
 
     # -- convenience endpoints --------------------------------------------
 

--- a/vgate-client/vgate_client/client.py
+++ b/vgate-client/vgate_client/client.py
@@ -116,6 +116,59 @@ def _parse_sse_line(line: str):
     return ChatCompletionChunk.model_validate(data)
 
 
+class SyncChatStream:
+    """Iterable wrapper around a streaming chat completion.
+
+    Supports plain iteration (``for chunk in client.chat.stream(...)``)
+    exactly like a generator — full exhaustion closes the underlying SSE
+    connection as before. It also supports use as a context manager
+    (``with client.chat.stream(...) as stream:``) so a caller who stops
+    iterating early (e.g. ``break``) can still guarantee the connection is
+    closed deterministically, rather than relying on the generator's
+    ``.close()`` being called explicitly or on GC eventually reclaiming it.
+    """
+
+    def __init__(self, generator: Iterator[ChatCompletionChunk]):
+        self._generator = generator
+
+    def __iter__(self) -> Iterator[ChatCompletionChunk]:
+        return self
+
+    def __next__(self) -> ChatCompletionChunk:
+        return next(self._generator)
+
+    def close(self) -> None:
+        self._generator.close()
+
+    def __enter__(self) -> "SyncChatStream":
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.close()
+
+
+class AsyncChatStream:
+    """Async counterpart of ``SyncChatStream``; see its docstring."""
+
+    def __init__(self, generator: AsyncIterator[ChatCompletionChunk]):
+        self._generator = generator
+
+    def __aiter__(self) -> AsyncIterator[ChatCompletionChunk]:
+        return self
+
+    async def __anext__(self) -> ChatCompletionChunk:
+        return await self._generator.__anext__()
+
+    async def aclose(self) -> None:
+        await self._generator.aclose()
+
+    async def __aenter__(self) -> "AsyncChatStream":
+        return self
+
+    async def __aexit__(self, *exc_info) -> None:
+        await self.aclose()
+
+
 def _check_stream_content_type(response: httpx.Response) -> None:
     content_type = response.headers.get("content-type", "")
     if "text/event-stream" not in content_type:
@@ -181,13 +234,17 @@ class _SyncChat:
         temperature: float = 0.7,
         top_p: float = 0.9,
         max_tokens: int = 256,
-    ) -> Iterator[ChatCompletionChunk]:
+    ) -> SyncChatStream:
         """Create a streaming chat completion.
 
-        Yields ``ChatCompletionChunk`` objects as they arrive over SSE. A
-        failure that happens after the stream has already started (mid-stream
-        error event, or the connection dropping) is not retried — retrying
-        would re-emit text the caller already received.
+        Returns a ``SyncChatStream`` yielding ``ChatCompletionChunk`` objects
+        as they arrive over SSE — iterate it directly, or use it as a context
+        manager (``with client.chat.stream(...) as stream:``) to guarantee
+        the connection closes even if you stop iterating early. A failure
+        that happens after the stream has already started (mid-stream error
+        event, connection dropping, or the stream ending without a `[DONE]`
+        event) is not retried — retrying would re-emit text the caller
+        already received.
         """
         req = ChatCompletionRequest(
             model=model,
@@ -197,7 +254,7 @@ class _SyncChat:
             max_tokens=max_tokens,
             stream=True,
         )
-        return self._client._stream_chat(req)
+        return SyncChatStream(self._client._stream_chat(req))
 
 
 class _SyncEmbeddings:
@@ -259,12 +316,15 @@ class _AsyncChat:
         temperature: float = 0.7,
         top_p: float = 0.9,
         max_tokens: int = 256,
-    ) -> AsyncIterator[ChatCompletionChunk]:
+    ) -> AsyncChatStream:
         """Create a streaming chat completion.
 
-        Not itself a coroutine — it returns an async generator immediately
+        Not itself a coroutine — it returns an ``AsyncChatStream`` immediately
         so ``async for chunk in client.chat.stream(...)`` works without an
-        extra ``await``, mirroring ``httpx.AsyncClient.stream()``.
+        extra ``await``, mirroring ``httpx.AsyncClient.stream()``. The
+        returned stream can also be used as an async context manager
+        (``async with client.chat.stream(...) as stream:``) to guarantee the
+        connection closes even if you stop iterating early.
         """
         req = ChatCompletionRequest(
             model=model,
@@ -274,7 +334,7 @@ class _AsyncChat:
             max_tokens=max_tokens,
             stream=True,
         )
-        return self._client._stream_chat(req)
+        return AsyncChatStream(self._client._stream_chat(req))
 
 
 class _AsyncEmbeddings:
@@ -378,12 +438,19 @@ class VGate:
                     response.read()
                     _raise_for_status(response)
                 _check_stream_content_type(response)
+                saw_done = False
                 for line in response.iter_lines():
                     parsed = _parse_sse_line(line)
                     if parsed is _STREAM_DONE:
-                        return
+                        saw_done = True
+                        break
                     if parsed is not None:
                         yield parsed
+                if not saw_done:
+                    raise ServerError(
+                        "Stream ended without a [DONE] event "
+                        "(connection closed early or the server crashed mid-stream)"
+                    )
         except httpx.ConnectError as exc:
             raise ConnectionError(f"Cannot connect to {self.base_url}: {exc}") from exc
 
@@ -501,12 +568,19 @@ class AsyncVGate:
                     await response.aread()
                     _raise_for_status(response)
                 _check_stream_content_type(response)
+                saw_done = False
                 async for line in response.aiter_lines():
                     parsed = _parse_sse_line(line)
                     if parsed is _STREAM_DONE:
-                        return
+                        saw_done = True
+                        break
                     if parsed is not None:
                         yield parsed
+                if not saw_done:
+                    raise ServerError(
+                        "Stream ended without a [DONE] event "
+                        "(connection closed early or the server crashed mid-stream)"
+                    )
         except httpx.ConnectError as exc:
             raise ConnectionError(f"Cannot connect to {self.base_url}: {exc}") from exc
 

--- a/vgate-client/vgate_client/models.py
+++ b/vgate-client/vgate_client/models.py
@@ -35,6 +35,7 @@ class ChatCompletionRequest(BaseModel):
     temperature: float = 0.7
     top_p: float = 0.9
     max_tokens: int = 256
+    stream: bool = False
 
 
 class EmbeddingRequest(BaseModel):
@@ -69,6 +70,25 @@ class ChatCompletion(BaseModel):
     model: str
     choices: list[Choice]
     usage: Usage = Field(default_factory=Usage)
+
+
+class ChatCompletionDelta(BaseModel):
+    role: Optional[str] = None
+    content: Optional[str] = None
+
+
+class ChatCompletionChunkChoice(BaseModel):
+    index: int
+    delta: ChatCompletionDelta
+    finish_reason: Optional[str] = None
+
+
+class ChatCompletionChunk(BaseModel):
+    id: str
+    object: str = "chat.completion.chunk"
+    created: int
+    model: str
+    choices: list[ChatCompletionChunkChoice]
 
 
 class EmbeddingData(BaseModel):


### PR DESCRIPTION
## Summary
- Adds `chat.stream(...)` to both `VGate` and `AsyncVGate`, consuming the server's existing SSE endpoint (already shipped in PR #29 for the dry-run + real vLLM backends) and yielding OpenAI-shaped `ChatCompletionChunk` objects — `chunk.choices[0].delta.content` — instead of leaving streaming reachable only via raw `curl`.
- New models: `ChatCompletionChunk` / `ChatCompletionChunkChoice` / `ChatCompletionDelta`, matching the nested OpenAI shape (not flattened), plus `stream: bool = False` on `ChatCompletionRequest`.
- Shared `_parse_sse_line` helper (used by both sync and async paths) skips blank/comment/non-`data:` lines, recognizes `data: [DONE]`, and raises `ServerError` on a mid-stream `{"error": ...}` event — before that malformed payload ever reaches Pydantic as an opaque validation error.
- HTTP status is checked (and the body read) before iterating; a 200 response with a non-`text/event-stream` Content-Type raises `VGateError` instead of silently yielding nothing.
- No retry once a stream has started (pre-connect failures still map to `ConnectionError`/`AuthenticationError`/`RateLimitError`/`ServerError` as before) — retrying after tokens were already yielded to the caller would duplicate text.
- Updates `ROADMAP.md` (Phase 2 task 4 → done) and `README.md` (SDK streaming usage examples for both clients).

This closes ROADMAP.md Phase 2 task 4. Remaining Phase 2 work (streaming-specific Prometheus metrics beyond basic logging, SGLang async streaming, redefining `RequestBatcher` as admission/dedup/fan-out) is unchanged and tracked separately.

## Test plan
- [x] `vgate-client/tests/test_streaming.py` (new): sync + async normal stream (role/content deltas/finish/`[DONE]`), request body actually sets `"stream": true`, HTTP 401/429/500 before any data, mid-stream error event → `ServerError`, unexpected Content-Type → `VGateError`, connect failure → `ConnectionError`, SSE context manager exits on both success and error paths, blank/comment lines ignored.
- [x] `vgate-client/tests/test_models.py`: chunk parsing for role/content/finish-reason chunks.
- [x] Full suites green: `VGATE_DRY_RUN=true pytest tests/` (153 passed — one unrelated rate-limiter timing test flaked under full-suite load, passes standalone and on rerun) and `pytest vgate-client/tests/` (68 passed).
- [x] Live integration smoke test against a running dry-run server (not just mocks) for both `VGate().chat.stream(...)` and `AsyncVGate().chat.stream(...)` — confirmed real chunks, correct `finish_reason`, and correctly reassembled content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)