### PR TITLE
feat: run inference in a separate worker process

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 The gateway tier is implemented — an OpenAI-shaped Chat Completions subset with streaming, dynamic micro-batching, result caching, observability, security, benchmarking, and container/Kubernetes deployment artifacts. The [vLLM](https://github.com/vllm-project/vllm) path has been exercised against a live GPU; the [SGLang](https://github.com/sgl-project/sglang) path is currently a unit-tested non-streaming adapter and has not yet been validated against a live SGLang engine.
 
-**The worker tier is not implemented yet.** The runtime today is one gateway process holding one in-process backend, not multi-worker serving. Splitting gateway from workers — worker registry, health checks, latency-aware routing, circuit breaking, and 1-vs-N worker evidence — is the current top priority and is tracked as [Phase 4](ROADMAP.md#phase-4-multi-worker-serving). Multimodal requests are a separate planned milestone. Live-GPU validation has been performed on one NVIDIA GeForce RTX 3060 Laptop GPU with 6GB VRAM; no RTX 4060 or multi-GPU validation is claimed.
+**The worker tier runs, but there is only one of it.** Inference can now be moved out of the gateway into a separate worker process (`role: worker`), and the gateway forwards to it over HTTP while keeping batching, caching, and admission control. What is still missing is everything that makes it *multi*-worker: a registry, health checks, routing strategies, and circuit breaking — tracked as [Phase 4](ROADMAP.md#phase-4-multi-worker-serving). Streaming through a worker is also not supported yet and returns 501. Multimodal requests are a separate planned milestone. Live-GPU validation has been performed on one NVIDIA GeForce RTX 3060 Laptop GPU with 6GB VRAM; no RTX 4060 or multi-GPU validation is claimed.
 
 ## Validated Evidence
 
@@ -39,7 +39,7 @@ The evidence below is a measured snapshot of the current serving path. The vLLM 
 | **Configuration as Code** | Implemented | YAML configuration with environment-variable overrides |
 | **Container Deployment** | Implemented | Docker CPU/GPU targets, Compose stack, and baseline Kubernetes manifests |
 | **Python Client SDK** | Implemented | Sync/async clients with deterministic streaming cleanup |
-| **Gateway/Worker Split** | Planned | Move inference out of the gateway process behind a worker API |
+| **Gateway/Worker Split** | Partial | Inference runs in a separate `role: worker` process reached over HTTP; one worker only, and streaming through a worker returns 501 |
 | **Worker Registry & Health** | Planned | Worker registration, health checks, and failure isolation |
 | **Latency-Aware Routing** | Planned | Round-robin, least-inflight, and EWMA-latency routing strategies |
 | **Circuit Breaking & Recovery** | Planned | Trip on unhealthy workers, drain, and rejoin on recovery |
@@ -48,35 +48,43 @@ The evidence below is a measured snapshot of the current serving path. The vLLM 
 
 ## Architecture
 
-Solid arrows are the current runtime; dashed arrows are the planned gateway/worker split. Today everything below runs inside a single process — the backend is called in-process, not over a worker API.
+Solid arrows are the current runtime; dashed arrows are not implemented yet. The gateway can either hold a backend in-process (the single-process default) or forward to one worker process — both paths exist today. Everything needed to run *more than one* worker is still missing.
 
 ```mermaid
 flowchart LR
     Client[Client / SDK] --> API[Gateway API]
 
-    subgraph GW[Gateway tier - implemented]
+    subgraph GW[Gateway process]
         API --> Sec[Auth / Rate limit]
         Sec --> NonStream[Non-streaming path]
         Sec --> Stream[Streaming path / SSE]
         NonStream --> Batcher[Admission / Batching / Cache]
     end
 
-    Batcher --> Backend[In-process backend]
-    Stream --> Backend
-    Backend --> VLLM[vLLM]
-    Backend --> SGLang[SGLang]
+    Batcher --> Local[In-process backend]
+    Stream --> Local
+    Local --> VLLM[vLLM]
+    Local --> SGLang[SGLang]
 
-    Batcher -. planned .-> Router[Router: round-robin / least-inflight / EWMA]
-    Router -. planned .-> Registry[Worker registry + health checks]
-    Registry -. planned .-> W1[Inference worker 1]
-    Registry -. planned .-> W2[Inference worker N]
-    Router -. planned .-> CB[Circuit breaker / recovery]
+    Batcher --> Remote[RemoteBackend / HTTP]
+
+    subgraph WK[Worker process]
+        Remote --> WAPI["/internal/generate"]
+        WAPI --> WEngine[Engine: vLLM or SGLang]
+    end
+
+    Remote -. not implemented .-> Router[Router: round-robin / least-inflight / EWMA]
+    Router -. not implemented .-> Registry[Worker registry + health checks]
+    Registry -. not implemented .-> W2[Workers 2..N]
+    Router -. not implemented .-> CB[Circuit breaker / recovery]
 
     GW --> Obs[Metrics / Logs / Traces]
-    W1 -. planned .-> Obs
+    WK --> Obs
 ```
 
-The target boundary: the gateway owns admission control, deduplication, caching, routing, and observability; each worker owns one engine instance and reports health and inflight load. That split is what makes 1-vs-N worker scaling, health-aware failover, and independent GPU-node placement measurable rather than hypothetical.
+The boundary: the gateway owns admission control, deduplication, caching, and observability; a worker owns one engine instance and nothing else. Because `RemoteBackend` implements the same `InferenceBackend` protocol as the local engines, the batcher does not know whether inference is local or remote — adding the worker hop required no change to it.
+
+That split is what makes 1-vs-N worker scaling, health-aware failover, and independent GPU-node placement measurable rather than hypothetical. None of those are measured yet; the routing layer that would make them possible is the next step.
 
 ---
 
@@ -140,6 +148,39 @@ pip install -r requirements.txt
 # Run server
 python main.py
 ```
+
+### Option 2b: Gateway + Worker (Split Mode)
+
+Run inference in a separate process. The gateway loads no model — it forwards
+to the worker and keeps batching, caching, and admission control.
+
+```bash
+# Terminal 1 — worker (owns the engine)
+VGATE_ROLE=worker VGATE_SERVER__PORT=8001 VGATE_DRY_RUN=true python main.py
+
+# Terminal 2 — gateway (holds no model)
+VGATE_ROLE=gateway VGATE_SERVER__PORT=8000 \
+  VGATE_WORKER__ENDPOINTS='["http://127.0.0.1:8001"]' python main.py
+
+# Requests go to the gateway as usual
+curl -X POST http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"test","messages":[{"role":"user","content":"hello"}],"max_tokens":16}'
+```
+
+Or with Compose:
+
+```bash
+docker compose --profile split up
+```
+
+Current limits of split mode:
+
+- **One worker.** Configuring more than one endpoint is rejected at startup rather than silently ignored; routing across workers needs the registry and health checks that come next.
+- **No streaming.** `stream: true` returns `501` before any SSE bytes are sent, instead of a `200` followed by an in-band error.
+- **No health checking.** If the worker is down, requests fail with `500` and a `worker unreachable` detail. The gateway itself stays up, and cached responses continue to be served.
+- The worker exposes only `/internal/generate`, `/health`, and `/metrics`; client-facing routes return `404` in the worker role.
+- With `security.enabled`, set `worker.api_key` on the gateway — `/internal/generate` is not an exempt path, so it requires the same bearer token as any other route.
 
 ### Option 3: Isolated SGLang Environment (Recommended)
 

--- a/config.yaml
+++ b/config.yaml
@@ -10,10 +10,33 @@
 
 version: "0.3.2"
 
+# Process role / 进程角色
+#   gateway: serves the public API, owns batching/caching/admission control
+#   worker:  runs inference only, exposes /internal/generate for a gateway
+role: "gateway"
+
 # Server settings / 服务器设置
 server:
   host: "0.0.0.0"
   port: 8000
+
+# Remote inference workers, read by the gateway role / 远程推理 worker
+#
+# Leave `endpoints` empty to keep inference in the gateway process (the
+# single-process default). Listing an endpoint moves inference to a separate
+# worker, and the gateway stops loading a model entirely.
+#
+# Streaming is not supported through a worker yet: stream=true returns 501.
+# Exactly one endpoint is supported for now; routing across several workers
+# needs a registry and health checks, which are not implemented yet.
+worker:
+  endpoints: []
+  # endpoints: ["http://127.0.0.1:8001"]
+  timeout_seconds: 120.0
+  connect_timeout_seconds: 5.0
+  # Sent as `Authorization: Bearer <key>` to the worker. Required when the
+  # worker runs with security.enabled, since /internal/generate is not exempt.
+  # api_key: "sk-vgate-worker-xxxxx"
 
 # Model configuration / 模型配置
 model:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,52 @@ services:
       - cpu
 
   # ---------------------------------------------------------------------------
+  # Split mode — gateway and inference worker as separate processes
+  # docker compose --profile split up
+  #
+  # The gateway holds no model: it owns admission, batching, caching, and
+  # observability, and forwards inference to the worker over HTTP. Runs on the
+  # CPU image with a dry-run worker so the topology can be exercised without a
+  # GPU. Streaming is not supported through a worker yet and returns 501.
+  # ---------------------------------------------------------------------------
+  vgate-gateway:
+    build:
+      context: .
+      target: vgate-cpu
+    image: vgate:cpu
+    ports:
+      - "8000:8000"
+    environment:
+      - VGATE_ROLE=gateway
+      - VGATE_CONFIG_PATH=/app/config.yaml
+      - VGATE_WORKER__ENDPOINTS=["http://vgate-worker:8000"]
+    depends_on:
+      vgate-worker:
+        condition: service_healthy
+    profiles:
+      - split
+
+  vgate-worker:
+    build:
+      context: .
+      target: vgate-cpu
+    image: vgate:cpu
+    environment:
+      - VGATE_ROLE=worker
+      - VGATE_DRY_RUN=true
+      - VGATE_CONFIG_PATH=/app/config.yaml
+    # Deliberately no published port: the worker is reachable only from the
+    # gateway on the compose network, not from the host.
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+    profiles:
+      - split
+
+  # ---------------------------------------------------------------------------
   # Prometheus — metrics collection
   # docker compose --profile monitoring up
   # ---------------------------------------------------------------------------

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel
 from contextlib import asynccontextmanager
@@ -34,6 +34,7 @@ from vgate.metrics import (
 )
 from vgate.security import SecurityMiddleware
 from vgate.tracing import init_tracing, shutdown_tracing, get_current_trace_id
+from vgate import worker_api
 
 # Prometheus client for metrics endpoint
 from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
@@ -47,6 +48,10 @@ app_logger = get_logger("vgate.app")
 
 # Version from config
 APP_VERSION = config.version
+
+# Role decides which half of the system this process runs: a gateway serves the
+# public API and owns batching/caching, a worker only runs inference.
+IS_WORKER = config.role == "worker"
 
 # Lazy initialization - will be set in lifespan
 engine = None
@@ -69,11 +74,31 @@ async def lifespan(app: FastAPI):
     # Initialize the VGateEngine with config (inside lifespan for multiprocessing safety)
     engine = VGateEngine()
 
-    # Initialize the RequestBatcher (uses config defaults)
-    batcher = RequestBatcher(engine=engine)
-
     # Initialize app info for Prometheus
     init_app_info(version=APP_VERSION, model=config.model.model_id)
+
+    if IS_WORKER:
+        # A worker only runs inference. Batching, caching, and admission
+        # control stay on the gateway; running them here too would batch and
+        # cache every request twice.
+        worker_api.set_engine(engine)
+        app_logger.info(
+            "V-Gate worker started",
+            extra={"extra_data": {
+                "version": APP_VERSION,
+                "model": config.model.model_id,
+                "engine_type": config.model.engine_type,
+                "security_enabled": config.security.enabled,
+            }}
+        )
+        yield
+        engine.backend.shutdown()
+        shutdown_tracing()
+        app_logger.info("V-Gate worker stopped")
+        return
+
+    # Initialize the RequestBatcher (uses config defaults)
+    batcher = RequestBatcher(engine=engine)
 
     # Startup: start the batcher
     await batcher.start()
@@ -83,6 +108,8 @@ async def lifespan(app: FastAPI):
             "version": APP_VERSION,
             "model": config.model.model_id,
             "engine_type": config.model.engine_type,
+            "inference": "remote" if engine.is_remote else "in-process",
+            "worker_endpoints": config.worker.endpoints,
             "batch_config": {
                 "max_batch_size": config.batch.max_batch_size,
                 "max_wait_time_ms": config.batch.max_wait_time_ms,
@@ -106,11 +133,24 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(
-    title="V-Gate LLM Inference Gateway",
-    description="An LLM inference gateway providing an OpenAI-shaped Chat Completions subset with streaming, admission control, dynamic micro-batching, result caching, and observability.",
+    title="V-Gate LLM Inference Worker" if IS_WORKER else "V-Gate LLM Inference Gateway",
+    description=(
+        "Internal inference worker for a V-Gate gateway. Not a public API surface."
+        if IS_WORKER else
+        "An LLM inference gateway providing an OpenAI-shaped Chat Completions subset "
+        "with streaming, admission control, dynamic micro-batching, result caching, "
+        "and observability."
+    ),
     version=APP_VERSION,
     lifespan=lifespan,
 )
+
+# Mounted only in the worker role, so a gateway never exposes an unbatched,
+# uncached inference endpoint. /internal/generate is deliberately not in
+# security.exempt_paths: with security enabled it requires the same bearer key
+# as any other route, which is what authenticates the gateway to the worker.
+if IS_WORKER:
+    app.include_router(worker_api.router)
 
 # Add security middleware (runs before observability middleware)
 # Note: Middlewares are executed in LIFO order, so add security first
@@ -201,12 +241,28 @@ def messages_to_prompt(messages: list[ChatMessage]) -> str:
     return "\n".join(prompt_parts) + "\nAssistant:"
 
 
+def gateway_only() -> None:
+    """
+    Reject client-facing routes in the worker role.
+
+    A worker has no batcher and no cache, so these handlers would fail on a
+    None batcher. Returning 404 states the intent: this surface does not exist
+    on a worker, rather than existing and being broken.
+    """
+    if IS_WORKER:
+        raise HTTPException(
+            status_code=404, detail="Not available in worker role; call the gateway instead"
+        )
+
+
 @app.get("/health", summary="Health Check")
 async def health_check():
     """
     Returns the health status of the V-Gate service.
+
+    Available in both roles: the gateway's worker health checks poll this.
     """
-    return {"status": "ok", "version": APP_VERSION}
+    return {"status": "ok", "version": APP_VERSION, "role": config.role}
 
 
 async def _stream_chat_completion(prompt: str, request: ChatCompletionRequest):
@@ -325,7 +381,8 @@ async def _stream_chat_completion(prompt: str, request: ChatCompletionRequest):
         yield "data: [DONE]\n\n"
 
 
-@app.post("/v1/chat/completions", summary="Create Chat Completion")
+@app.post("/v1/chat/completions", summary="Create Chat Completion",
+          dependencies=[Depends(gateway_only)])
 async def create_chat_completion(request: ChatCompletionRequest):
     """
     Generates a chat completion response from the specified model.
@@ -334,6 +391,19 @@ async def create_chat_completion(request: ChatCompletionRequest):
     _stream_chat_completion for why.
     """
     if request.stream:
+        # Reject before any SSE bytes are written. Once the 200 and stream
+        # headers are flushed the only way to report this is an in-band error
+        # event, which reads to a client as "the request succeeded and then
+        # something went wrong mid-stream" — misleading when the backend never
+        # supported streaming at all.
+        if not getattr(engine.backend, "supports_streaming", True):
+            raise HTTPException(
+                status_code=501,
+                detail=(
+                    "Streaming is not supported when the gateway forwards to remote "
+                    "workers. Send stream=false, or run a gateway with an in-process backend."
+                ),
+            )
         prompt = messages_to_prompt(request.messages)
         return StreamingResponse(
             _stream_chat_completion(prompt, request),
@@ -382,7 +452,8 @@ async def create_chat_completion(request: ChatCompletionRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@app.post("/v1/embeddings", summary="Create Embeddings")
+@app.post("/v1/embeddings", summary="Create Embeddings",
+          dependencies=[Depends(gateway_only)])
 async def create_embeddings(request: EmbeddingRequest):
     """
     Generates embeddings for the given input text from the specified model.
@@ -425,7 +496,8 @@ async def prometheus_metrics(request: Request):
     )
 
 
-@app.get("/stats", summary="JSON Statistics")
+@app.get("/stats", summary="JSON Statistics",
+         dependencies=[Depends(gateway_only)])
 async def get_stats():
     """
     Returns metrics about the request batching system and cache in JSON format.
@@ -473,7 +545,8 @@ class BenchmarkRequest(BaseModel):
     rounds: int = 3
 
 
-@app.post("/v1/benchmark", summary="Run Inline Benchmark")
+@app.post("/v1/benchmark", summary="Run Inline Benchmark",
+          dependencies=[Depends(gateway_only)])
 async def run_benchmark(request: BenchmarkRequest):
     """
     Run a quick inline benchmark through the full pipeline (batcher + cache + engine).

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,8 @@ opentelemetry-api>=1.25.0
 opentelemetry-sdk>=1.25.0
 opentelemetry-exporter-otlp-proto-grpc>=1.25.0
 opentelemetry-instrumentation-fastapi>=0.46b0
+# Gateway -> worker transport for RemoteBackend (role=gateway with worker endpoints)
+httpx>=0.27.0
 # vllm>=0.14.0  # GPU mode: provided by base image
 # sglang[all]>=0.4.0  # SGLang mode: alternative backend
 

--- a/tests/test_worker_split.py
+++ b/tests/test_worker_split.py
@@ -1,0 +1,359 @@
+# Copyright 2025 the V-Gate authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the gateway/worker split.
+
+The end-to-end test wires a real RemoteBackend to a real worker app through an
+httpx transport, so the request actually crosses the RemoteBackend ->
+/internal/generate boundary rather than being mocked at the seam being tested.
+"""
+
+import asyncio
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vgate.backends.base import DryRunBackend, InferenceBackend
+from vgate.backends.remote_backend import RemoteBackend, RemoteInferenceError
+from vgate.batcher import RequestBatcher
+from vgate.config import VGateConfig, WorkerConfig
+from vgate.engine import _create_backend
+from vgate import worker_api
+
+
+# --------------------------------------------------------------------------
+# Config
+# --------------------------------------------------------------------------
+
+def test_role_defaults_to_gateway():
+    assert VGateConfig().role == "gateway"
+
+
+def test_role_rejects_unknown_value():
+    with pytest.raises(ValueError, match="role must be one of"):
+        VGateConfig(role="coordinator")
+
+
+def test_worker_endpoints_require_http_scheme():
+    with pytest.raises(ValueError, match="must start with http"):
+        WorkerConfig(endpoints=["worker-1:8001"])
+
+
+def test_worker_endpoints_strip_trailing_slash():
+    cfg = WorkerConfig(endpoints=["http://worker-1:8001/"])
+    assert cfg.endpoints == ["http://worker-1:8001"]
+
+
+# --------------------------------------------------------------------------
+# Backend factory
+# --------------------------------------------------------------------------
+
+def test_factory_returns_local_backend_without_endpoints():
+    backend = _create_backend("vllm", WorkerConfig())
+    assert isinstance(backend, DryRunBackend)  # VGATE_DRY_RUN=true in tests
+
+
+def test_factory_returns_remote_backend_with_endpoints():
+    backend = _create_backend("vllm", WorkerConfig(endpoints=["http://w:8001"]))
+    assert isinstance(backend, RemoteBackend)
+    backend.shutdown()
+
+
+def test_remote_backend_satisfies_protocol():
+    backend = RemoteBackend(WorkerConfig(endpoints=["http://w:8001"]))
+    assert isinstance(backend, InferenceBackend)
+    backend.shutdown()
+
+
+def test_remote_backend_rejects_multiple_endpoints():
+    # Multi-worker routing is not implemented yet; failing loudly beats
+    # silently using only the first endpoint.
+    with pytest.raises(ValueError, match="one worker endpoint"):
+        RemoteBackend(WorkerConfig(endpoints=["http://a:8001", "http://b:8001"]))
+
+
+def test_remote_backend_requires_an_endpoint():
+    with pytest.raises(ValueError, match="at least one worker endpoint"):
+        RemoteBackend(WorkerConfig())
+
+
+# --------------------------------------------------------------------------
+# Worker app
+# --------------------------------------------------------------------------
+
+def _make_worker_app() -> FastAPI:
+    """A minimal worker app: just the internal router bound to a dry-run engine."""
+    class _Engine:
+        backend = DryRunBackend()
+
+    app = FastAPI()
+    app.include_router(worker_api.router)
+    worker_api.set_engine(_Engine())
+    return app
+
+
+def test_worker_generate_returns_backend_shaped_results():
+    with TestClient(_make_worker_app()) as client:
+        response = client.post(
+            "/internal/generate",
+            json={
+                "prompts": ["hello", "world"],
+                "sampling_params": {"temperature": 0.1, "top_p": 0.9, "max_tokens": 16},
+            },
+        )
+    assert response.status_code == 200
+    results = response.json()["results"]
+    assert len(results) == 2
+    # Same keys the InferenceBackend protocol promises, so RemoteBackend can
+    # hand them straight back to the batcher.
+    for result in results:
+        assert set(result) >= {"text", "num_tokens", "metrics"}
+
+
+def test_worker_rejects_empty_prompts():
+    with TestClient(_make_worker_app()) as client:
+        response = client.post("/internal/generate", json={"prompts": []})
+    assert response.status_code == 422
+
+
+def test_worker_returns_503_before_engine_is_bound():
+    app = FastAPI()
+    app.include_router(worker_api.router)
+    worker_api._engine = None
+    try:
+        with TestClient(app) as client:
+            response = client.post("/internal/generate", json={"prompts": ["x"]})
+        assert response.status_code == 503
+    finally:
+        worker_api.set_engine(type("E", (), {"backend": DryRunBackend()})())
+
+
+# --------------------------------------------------------------------------
+# End-to-end: RemoteBackend -> worker app
+# --------------------------------------------------------------------------
+
+def _remote_backend_wired_to(app: FastAPI, **kwargs) -> RemoteBackend:
+    """
+    RemoteBackend whose HTTP client drives `app` in-process.
+
+    TestClient subclasses httpx.Client and drives an ASGI app through a
+    synchronous transport, which is what RemoteBackend.generate() needs --
+    httpx.ASGITransport is async-only and cannot back a sync Client.
+    """
+    backend = RemoteBackend(WorkerConfig(endpoints=["http://testserver"], **kwargs))
+    configured_headers = dict(backend._client.headers)
+    backend._client.close()
+
+    test_client = TestClient(app)
+    test_client.headers.update(configured_headers)
+    backend._client = test_client
+    return backend
+
+
+def test_remote_backend_forwards_generate_to_worker():
+    backend = _remote_backend_wired_to(_make_worker_app())
+    try:
+        params = backend.create_sampling_params(temperature=0.5, top_p=0.9, max_tokens=8)
+        results = backend.generate(["ping"], params)
+    finally:
+        backend.shutdown()
+
+    assert len(results) == 1
+    assert "text" in results[0]
+    assert results[0]["num_tokens"] == 8
+
+
+def test_remote_backend_raises_when_worker_unreachable():
+    backend = RemoteBackend(
+        WorkerConfig(endpoints=["http://127.0.0.1:1"], connect_timeout_seconds=0.1)
+    )
+    try:
+        with pytest.raises(RemoteInferenceError, match="unreachable"):
+            backend.generate(["ping"], {"temperature": 0.7, "top_p": 0.9, "max_tokens": 4})
+    finally:
+        backend.shutdown()
+
+
+def test_remote_backend_raises_on_worker_error_status():
+    app = FastAPI()
+
+    @app.post("/internal/generate")
+    async def _boom():
+        from fastapi.responses import JSONResponse
+        return JSONResponse(status_code=500, content={"detail": "Inference failed"})
+
+    backend = _remote_backend_wired_to(app)
+    try:
+        with pytest.raises(RemoteInferenceError, match="returned 500"):
+            backend.generate(["ping"], {"temperature": 0.7, "top_p": 0.9, "max_tokens": 4})
+    finally:
+        backend.shutdown()
+
+
+def test_remote_backend_rejects_result_count_mismatch():
+    app = FastAPI()
+
+    @app.post("/internal/generate")
+    async def _short():
+        return {"results": [{"text": "only one", "num_tokens": 1, "metrics": {}}]}
+
+    backend = _remote_backend_wired_to(app)
+    try:
+        with pytest.raises(RemoteInferenceError, match="for 2 prompts"):
+            backend.generate(["a", "b"], {"temperature": 0.7, "top_p": 0.9, "max_tokens": 4})
+    finally:
+        backend.shutdown()
+
+
+def test_remote_backend_sends_bearer_token_when_configured():
+    seen = {}
+    app = FastAPI()
+
+    @app.post("/internal/generate")
+    async def _echo():
+        return {"results": [{"text": "ok", "num_tokens": 1, "metrics": {}}]}
+
+    @app.middleware("http")
+    async def _capture(request, call_next):
+        seen["auth"] = request.headers.get("Authorization")
+        return await call_next(request)
+
+    backend = _remote_backend_wired_to(app, api_key="sk-worker-test")
+    try:
+        backend.generate(["x"], {"temperature": 0.7, "top_p": 0.9, "max_tokens": 4})
+    finally:
+        backend.shutdown()
+
+    assert seen["auth"] == "Bearer sk-worker-test"
+
+
+def test_gateway_returns_501_for_streaming_with_remote_backend(monkeypatch):
+    """
+    The 501 must land before any SSE byte is written.
+
+    A 200 followed by an in-band error event reads to a client as "succeeded,
+    then broke mid-stream", which is wrong when the backend never supported
+    streaming at all.
+    """
+    import main as main_module
+
+    backend = RemoteBackend(WorkerConfig(endpoints=["http://w:8001"]))
+    try:
+        with TestClient(main_module.app) as client:
+            # Patch inside the context: the app lifespan builds a fresh engine
+            # on startup and would overwrite an earlier patch.
+            monkeypatch.setattr(main_module, "engine", _Engine(backend))
+            response = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "test",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": True,
+                },
+            )
+    finally:
+        backend.shutdown()
+
+    assert response.status_code == 501
+    assert "streaming is not supported" in response.json()["detail"].lower()
+    assert "text/event-stream" not in response.headers.get("content-type", "")
+
+
+def test_gateway_allows_streaming_with_local_backend(monkeypatch):
+    """The 501 guard must not fire for backends that do support streaming."""
+    import main as main_module
+
+    with TestClient(main_module.app) as client:
+        monkeypatch.setattr(main_module, "engine", _Engine(DryRunBackend()))
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": True,
+                "max_tokens": 4,
+            },
+        )
+    assert response.status_code == 200
+    assert "text/event-stream" in response.headers["content-type"]
+
+
+@pytest.mark.asyncio
+async def test_remote_backend_streaming_raises_not_implemented():
+    backend = RemoteBackend(WorkerConfig(endpoints=["http://w:8001"]))
+    try:
+        with pytest.raises(NotImplementedError, match="Streaming is not supported"):
+            async for _ in backend.stream_generate("hi", {"max_tokens": 4}):
+                pass
+    finally:
+        backend.shutdown()
+
+
+# --------------------------------------------------------------------------
+# Batcher lock behavior
+# --------------------------------------------------------------------------
+
+class _Engine:
+    def __init__(self, backend):
+        self.backend = backend
+
+
+def test_batcher_serializes_local_backends():
+    batcher = RequestBatcher(engine=_Engine(DryRunBackend()))
+    assert batcher._serialize_inference is True
+
+
+def test_batcher_does_not_serialize_concurrent_safe_backends():
+    # Otherwise every worker call would queue behind the previous one and
+    # adding workers would not increase throughput.
+    backend = RemoteBackend(WorkerConfig(endpoints=["http://w:8001"]))
+    try:
+        batcher = RequestBatcher(engine=_Engine(backend))
+        assert batcher._serialize_inference is False
+    finally:
+        backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_batches_overlap_with_remote_backend():
+    """Two batches should be in flight at once when the backend allows it."""
+    concurrent = 0
+    peak = 0
+
+    class _SlowConcurrentBackend:
+        supports_concurrent_calls = True
+
+        def create_sampling_params(self, temperature, top_p, max_tokens):
+            return {"temperature": temperature, "top_p": top_p, "max_tokens": max_tokens}
+
+        def generate(self, prompts, sampling_params):
+            nonlocal concurrent, peak
+            concurrent += 1
+            peak = max(peak, concurrent)
+            import time as _t
+            _t.sleep(0.05)
+            concurrent -= 1
+            return [{"text": p, "token_ids": [], "num_tokens": 1, "metrics": {}} for p in prompts]
+
+    batcher = RequestBatcher(engine=_Engine(_SlowConcurrentBackend()), max_batch_size=1)
+    await batcher.start()
+    try:
+        await asyncio.gather(*(batcher.submit(f"p{i}", max_tokens=4) for i in range(4)))
+    finally:
+        await batcher.stop()
+
+    assert peak > 1, f"expected overlapping batches, peak concurrency was {peak}"

--- a/vgate/backends/remote_backend.py
+++ b/vgate/backends/remote_backend.py
@@ -1,0 +1,158 @@
+# Copyright 2025 the V-Gate authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Remote inference backend.
+
+Implements the same InferenceBackend protocol as VLLMBackend and SGLangBackend,
+but forwards generation to a separate worker process over HTTP instead of
+holding an engine in the gateway process. Because it satisfies the protocol,
+RequestBatcher does not need to know whether inference is local or remote.
+
+generate() is synchronous to match the protocol: RequestBatcher already calls
+it through run_in_executor, so a blocking HTTP call there does not block the
+event loop.
+"""
+
+from typing import Any, AsyncIterator, Dict, List
+
+import httpx
+
+from vgate.config import ModelConfig, WorkerConfig
+from vgate.logging_config import get_logger
+from vgate.tracing import get_tracer
+
+logger = get_logger("vgate.backends.remote")
+tracer = get_tracer("vgate.backends.remote")
+
+
+class RemoteInferenceError(RuntimeError):
+    """Raised when a worker cannot be reached or returns an error response."""
+
+
+class RemoteBackend:
+    """Forwards inference to a remote V-Gate worker over HTTP."""
+
+    # Unlike the in-process engines, concurrent calls are safe here: each call
+    # is an independent HTTP request and the worker serializes as needed on its
+    # own side. RequestBatcher reads this to decide whether to hold its
+    # inference lock, which would otherwise serialize every worker call and
+    # defeat the point of running more than one worker.
+    supports_concurrent_calls = True
+
+    # Streaming over a worker hop is not implemented yet. The gateway checks
+    # this before opening an SSE response, so clients get a 501 instead of a
+    # 200 followed by an in-band error event.
+    supports_streaming = False
+
+    def __init__(self, worker_config: WorkerConfig):
+        if not worker_config.endpoints:
+            raise ValueError("RemoteBackend requires at least one worker endpoint")
+
+        self.config = worker_config
+        # PR1 targets a single worker. Routing across several endpoints, with a
+        # registry and health checks, is the next change; until then an extra
+        # endpoint would be silently ignored, so refuse it explicitly.
+        if len(worker_config.endpoints) > 1:
+            raise ValueError(
+                "RemoteBackend currently supports exactly one worker endpoint; "
+                f"got {len(worker_config.endpoints)}. Multi-worker routing is not implemented yet."
+            )
+        self.endpoint = worker_config.endpoints[0]
+
+        headers = {}
+        if worker_config.api_key:
+            headers["Authorization"] = f"Bearer {worker_config.api_key}"
+
+        self._client = httpx.Client(
+            timeout=httpx.Timeout(
+                worker_config.timeout_seconds,
+                connect=worker_config.connect_timeout_seconds,
+            ),
+            headers=headers,
+        )
+        logger.info(
+            "Remote backend initialized",
+            extra={"extra_data": {
+                "endpoint": self.endpoint,
+                "timeout_seconds": worker_config.timeout_seconds,
+                "authenticated": bool(worker_config.api_key),
+            }}
+        )
+
+    def load_model(self, model_config: ModelConfig) -> None:
+        """No-op: the worker process owns model loading."""
+
+    def create_sampling_params(
+        self, temperature: float, top_p: float, max_tokens: int
+    ) -> Any:
+        # Plain dict so it survives JSON transport; the worker rebuilds
+        # engine-native params from it.
+        return {"temperature": temperature, "top_p": top_p, "max_tokens": max_tokens}
+
+    def generate(
+        self, prompts: List[str], sampling_params: Any
+    ) -> List[Dict[str, Any]]:
+        with tracer.start_as_current_span("remote.generate") as span:
+            span.set_attribute("num_prompts", len(prompts))
+            span.set_attribute("endpoint", self.endpoint)
+
+            try:
+                response = self._client.post(
+                    f"{self.endpoint}/internal/generate",
+                    json={"prompts": prompts, "sampling_params": sampling_params},
+                )
+            except httpx.RequestError as exc:
+                span.set_attribute("error", True)
+                raise RemoteInferenceError(
+                    f"worker at {self.endpoint} unreachable: {type(exc).__name__}"
+                ) from exc
+
+            if response.status_code != 200:
+                span.set_attribute("error", True)
+                # Worker error bodies may echo prompt text; keep only a bounded
+                # prefix out of the exception message.
+                raise RemoteInferenceError(
+                    f"worker at {self.endpoint} returned {response.status_code}: "
+                    f"{response.text[:200]}"
+                )
+
+            payload = response.json()
+            results = payload.get("results")
+            if not isinstance(results, list) or len(results) != len(prompts):
+                raise RemoteInferenceError(
+                    f"worker at {self.endpoint} returned {len(results) if isinstance(results, list) else 'no'} "
+                    f"results for {len(prompts)} prompts"
+                )
+            return results
+
+    async def stream_generate(
+        self, prompt: str, sampling_params: Any
+    ) -> AsyncIterator[Dict[str, Any]]:
+        """
+        Not implemented yet.
+
+        Streaming over a worker hop needs cancellation to propagate through
+        two connections (client -> gateway -> worker); doing that correctly is
+        its own change. Until then this fails loudly rather than silently
+        degrading to a non-streaming response.
+        """
+        raise NotImplementedError(
+            "Streaming is not supported with remote workers yet. "
+            "Use a gateway with an in-process backend for streaming requests."
+        )
+        yield  # pragma: no cover  - makes this an async generator
+
+    def shutdown(self) -> None:
+        self._client.close()

--- a/vgate/batcher.py
+++ b/vgate/batcher.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import time
+from contextlib import nullcontext
 from typing import Any, Dict, List, Optional
 from dataclasses import dataclass, field
 
@@ -77,6 +78,14 @@ class RequestBatcher:
         self._queue: List[BatchRequest] = []
         self._lock = asyncio.Lock()
         self._inference_lock = asyncio.Lock()  # Prevent concurrent vLLM calls
+        # In-process engines are not safe to call concurrently, so batches are
+        # serialized through _inference_lock. A backend that forwards over the
+        # network has no such constraint, and holding the lock there would
+        # serialize every worker call — making additional workers useless.
+        # Backends opt out by declaring supports_concurrent_calls; the default
+        # stays locked, so local backends are unaffected.
+        backend = getattr(engine, "backend", None)
+        self._serialize_inference = not getattr(backend, "supports_concurrent_calls", False)
         self._batch_task: asyncio.Task = None
         self._running = False
 
@@ -223,8 +232,10 @@ class RequestBatcher:
 
     async def _process_batch(self):
         """Process up to max_batch_size pending requests as a batch, with deduplication."""
-        # Use inference lock to prevent concurrent vLLM calls
-        async with self._inference_lock:
+        # Serialize batches only when the backend requires it (see __init__).
+        # nullcontext supports async use on Python 3.10+.
+        inference_guard = self._inference_lock if self._serialize_inference else nullcontext()
+        async with inference_guard:
             async with self._lock:
                 if not self._queue:
                     return

--- a/vgate/config.py
+++ b/vgate/config.py
@@ -40,6 +40,35 @@ class ServerConfig(BaseModel):
     port: int = 8000
 
 
+class WorkerConfig(BaseModel):
+    """
+    Remote inference worker settings, read by the gateway role.
+
+    When `endpoints` is empty the gateway keeps the historical behavior of
+    holding an in-process backend, so existing single-process deployments are
+    unaffected. Listing endpoints switches the gateway to RemoteBackend.
+    """
+    endpoints: list[str] = Field(default_factory=list)
+    # Generous by default: a cold worker may still be loading model weights
+    # when the first request arrives.
+    timeout_seconds: float = 120.0
+    connect_timeout_seconds: float = 5.0
+    # Sent as `Authorization: Bearer <api_key>` to the worker. Needed when the
+    # worker runs with security.enabled, since /internal/generate is not an
+    # exempt path.
+    api_key: Optional[str] = None
+
+    @field_validator("endpoints")
+    @classmethod
+    def validate_endpoints(cls, v: list[str]) -> list[str]:
+        for endpoint in v:
+            if not endpoint.startswith(("http://", "https://")):
+                raise ValueError(
+                    f"worker endpoint must start with http:// or https://, got {endpoint!r}"
+                )
+        return [e.rstrip("/") for e in v]
+
+
 class ModelConfig(BaseModel):
     """Model configuration for inference engine."""
     model_id: str = "Qwen/Qwen2.5-1.5B-Instruct-AWQ"
@@ -190,7 +219,11 @@ class VGateConfig(BaseSettings):
     )
 
     version: str = "0.3.2"
+    # "gateway" runs admission, batching, caching, and routing. "worker" runs
+    # only inference and exposes the internal generate API.
+    role: str = "gateway"
     server: ServerConfig = Field(default_factory=ServerConfig)
+    worker: WorkerConfig = Field(default_factory=WorkerConfig)
     model: ModelConfig = Field(default_factory=ModelConfig)
     batch: BatchConfig = Field(default_factory=BatchConfig)
     cache: CacheConfig = Field(default_factory=CacheConfig)
@@ -200,6 +233,14 @@ class VGateConfig(BaseSettings):
     security: SecurityConfig = Field(default_factory=SecurityConfig)
     tracing: TracingConfig = Field(default_factory=TracingConfig)
     benchmark: BenchmarkConfig = Field(default_factory=BenchmarkConfig)
+
+    @field_validator("role")
+    @classmethod
+    def validate_role(cls, v: str) -> str:
+        allowed = ("gateway", "worker")
+        if v not in allowed:
+            raise ValueError(f"role must be one of {allowed}, got '{v}'")
+        return v
 
     @classmethod
     def settings_customise_sources(

--- a/vgate/engine.py
+++ b/vgate/engine.py
@@ -17,7 +17,7 @@ import time
 from typing import Optional
 
 from vgate.backends.base import DryRunBackend, InferenceBackend
-from vgate.config import ModelConfig, get_config
+from vgate.config import ModelConfig, WorkerConfig, get_config
 from vgate.tracing import get_tracer
 
 tracer = get_tracer("vgate.engine")
@@ -25,8 +25,21 @@ tracer = get_tracer("vgate.engine")
 DRY_RUN = os.getenv("VGATE_DRY_RUN", "false").lower() in ("true", "1", "yes")
 
 
-def _create_backend(engine_type: str) -> InferenceBackend:
-    """Factory function to create the appropriate inference backend."""
+def _create_backend(
+    engine_type: str, worker_config: Optional[WorkerConfig] = None
+) -> InferenceBackend:
+    """
+    Factory function to create the appropriate inference backend.
+
+    A gateway configured with worker endpoints forwards inference instead of
+    running it, so that check comes before DRY_RUN and engine_type: those
+    describe how the *worker* runs a model, and are irrelevant to a process
+    that only forwards. Without any endpoints the historical single-process
+    behavior is preserved.
+    """
+    if worker_config is not None and worker_config.endpoints:
+        from vgate.backends.remote_backend import RemoteBackend
+        return RemoteBackend(worker_config)
     if DRY_RUN:
         return DryRunBackend()
     if engine_type == "vllm":
@@ -39,19 +52,34 @@ def _create_backend(engine_type: str) -> InferenceBackend:
 
 
 class VGateEngine:
-    def __init__(self, model_config: Optional[ModelConfig] = None):
+    def __init__(
+        self,
+        model_config: Optional[ModelConfig] = None,
+        worker_config: Optional[WorkerConfig] = None,
+    ):
         """
         Initialize the inference engine with configuration.
 
         Args:
             model_config: Model configuration. If None, uses global config.
+            worker_config: Remote worker settings. If it lists endpoints, this
+                engine forwards inference instead of loading a model locally.
+                If None, uses global config.
         """
+        config = get_config()
         if model_config is None:
-            model_config = get_config().model
+            model_config = config.model
+        if worker_config is None:
+            worker_config = config.worker
 
-        self.backend: InferenceBackend = _create_backend(model_config.engine_type)
+        self.is_remote = bool(worker_config.endpoints)
+        self.backend: InferenceBackend = _create_backend(
+            model_config.engine_type, worker_config
+        )
 
-        if DRY_RUN:
+        if self.is_remote:
+            print(f"V-Gate gateway forwarding inference to {worker_config.endpoints}")
+        elif DRY_RUN:
             print("V-Gate starting in DRY-RUN mode (no GPU required)")
         else:
             self.backend.load_model(model_config)

--- a/vgate/worker_api.py
+++ b/vgate/worker_api.py
@@ -1,0 +1,125 @@
+# Copyright 2025 the V-Gate authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Worker-role API.
+
+A worker owns one engine instance and nothing else: no batching, no cache, no
+admission control. Those belong to the gateway, and duplicating them here would
+mean every request is batched and cached twice.
+
+The request/response shape is deliberately the wire form of
+InferenceBackend.generate(), so RemoteBackend on the gateway side is a
+transport for that method rather than a second API with its own semantics.
+"""
+
+import asyncio
+import time
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from vgate.logging_config import get_logger
+from vgate.metrics import INFERENCE_ERRORS
+from vgate.tracing import get_tracer
+
+logger = get_logger("vgate.worker")
+tracer = get_tracer("vgate.worker")
+
+router = APIRouter(tags=["worker"])
+
+# Set by main.py during lifespan when running with role=worker.
+_engine = None
+# The in-process engines are not safe to call concurrently, which is why the
+# gateway's batcher holds a lock around local backends. That lock lives on the
+# gateway, so once inference moves here the worker has to enforce it itself.
+_inference_lock: asyncio.Lock | None = None
+
+
+def set_engine(engine) -> None:
+    """Bind the worker's engine. Called once from the app lifespan."""
+    global _engine, _inference_lock
+    _engine = engine
+    _inference_lock = asyncio.Lock()
+
+
+class SamplingParams(BaseModel):
+    temperature: float = 0.7
+    top_p: float = 0.9
+    max_tokens: int = 256
+
+
+class GenerateRequest(BaseModel):
+    prompts: List[str] = Field(..., min_length=1)
+    sampling_params: SamplingParams = Field(default_factory=SamplingParams)
+
+
+class GenerateResponse(BaseModel):
+    results: List[Dict[str, Any]]
+
+
+@router.post("/internal/generate", summary="Internal Generate (worker role)")
+async def internal_generate(request: GenerateRequest) -> GenerateResponse:
+    """
+    Run inference for a batch of prompts.
+
+    Not part of the public API surface: the gateway calls this, clients do not.
+    """
+    if _engine is None:
+        raise HTTPException(status_code=503, detail="Worker engine not initialized")
+
+    with tracer.start_as_current_span("worker.generate") as span:
+        span.set_attribute("num_prompts", len(request.prompts))
+
+        backend = _engine.backend
+        sampling_params = backend.create_sampling_params(
+            temperature=request.sampling_params.temperature,
+            top_p=request.sampling_params.top_p,
+            max_tokens=request.sampling_params.max_tokens,
+        )
+
+        started = time.perf_counter()
+        try:
+            # Serialize engine access, then run the blocking call off the event
+            # loop so this worker can still answer /health while generating.
+            async with _inference_lock:
+                results = await asyncio.get_running_loop().run_in_executor(
+                    None, backend.generate, request.prompts, sampling_params
+                )
+        except Exception as exc:
+            span.set_attribute("error", True)
+            INFERENCE_ERRORS.labels(error_type=type(exc).__name__).inc()
+            logger.error(
+                "Worker inference failed",
+                extra={"extra_data": {
+                    "error": str(exc),
+                    "error_type": type(exc).__name__,
+                    "num_prompts": len(request.prompts),
+                }}
+            )
+            raise HTTPException(
+                status_code=500, detail=f"Inference failed: {type(exc).__name__}"
+            ) from exc
+
+        duration = time.perf_counter() - started
+        span.set_attribute("duration_s", round(duration, 4))
+        logger.info(
+            "Worker batch completed",
+            extra={"extra_data": {
+                "num_prompts": len(request.prompts),
+                "duration_ms": round(duration * 1000, 2),
+            }}
+        )
+        return GenerateResponse(results=results)


### PR DESCRIPTION
**1 of 2.** Moves inference out of the gateway process. [#next](../../pulls) stacks the multi-worker routing on top.

A process started with `role: worker` owns one engine and exposes `/internal/generate`; a gateway configured with `worker.endpoints` reaches it through `RemoteBackend` over HTTP and keeps admission, batching, caching, and observability for itself.

## The batcher did not change

`RemoteBackend` implements the existing `InferenceBackend` protocol, so `RequestBatcher` works across a process boundary without modification — it still calls `backend.generate()` and does not know whether the engine is local or a hop away. Keeping `generate()` synchronous matches the protocol and is safe because the batcher already dispatches it through `run_in_executor`.

## Two things that had to change beyond adding transport

**The inference lock had to become conditional.** `RequestBatcher` held `_inference_lock` around every batch because in-process engines are not safe to call concurrently. Kept as-is for a network backend, that lock serializes every worker call and makes additional workers pointless. Backends now declare `supports_concurrent_calls`; the default stays locked, so local backends are unaffected. The worker enforces the same serialization on its own side, since the lock it used to rely on now lives in a different process.

**Streaming had to fail before the stream opens.** Left alone, a stream request got a `200` plus an SSE error event, which reads to a client as a mid-stream failure rather than an unsupported feature. The gateway now checks `supports_streaming` and returns `501` before any SSE byte is written.

## Verified with live processes

- A gateway with `VGATE_DRY_RUN` **unset** serves completions without loading a model — logs show no engine init, proving inference is genuinely remote
- The worker logs the forwarded batches
- Worker-role processes return `404` on client-facing routes
- Streaming returns `501`; non-streaming returns `200`
- Killing the worker yields `500` with a `worker unreachable` detail while the gateway stays up and still serves cached responses

## Scope limits, enforced rather than documented away

Exactly one endpoint is accepted and more are rejected at startup; there is no health checking or routing; `/internal/generate` is not an exempt path, so it requires the same bearer token as any other route when security is enabled.

## Tests

`tests/` 188 passed (23 new), `vgate-client/tests/` 74 passed.

Compose gains a `split` profile. It is **YAML-validated only** — Docker is not available in this environment, so the containerized topology has not been run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)