### PR TITLE
feat: route across multiple workers with health-based failover (re-target of #36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 The gateway tier is implemented — an OpenAI-shaped Chat Completions subset with streaming, dynamic micro-batching, result caching, observability, security, benchmarking, and container/Kubernetes deployment artifacts. The [vLLM](https://github.com/vllm-project/vllm) path has been exercised against a live GPU; the [SGLang](https://github.com/sgl-project/sglang) path is currently a unit-tested non-streaming adapter and has not yet been validated against a live SGLang engine.
 
-**The worker tier runs, but there is only one of it.** Inference can now be moved out of the gateway into a separate worker process (`role: worker`), and the gateway forwards to it over HTTP while keeping batching, caching, and admission control. What is still missing is everything that makes it *multi*-worker: a registry, health checks, routing strategies, and circuit breaking — tracked as [Phase 4](ROADMAP.md#phase-4-multi-worker-serving). Streaming through a worker is also not supported yet and returns 501. Multimodal requests are a separate planned milestone. Live-GPU validation has been performed on one NVIDIA GeForce RTX 3060 Laptop GPU with 6GB VRAM; no RTX 4060 or multi-GPU validation is claimed.
+**Multi-worker serving runs, but has not been benchmarked.** Inference happens in separate `role: worker` processes; the gateway routes across them round-robin, probes their health in the background, removes failing workers from rotation, and lets them rejoin once they recover. A killed worker does not fail requests — traffic shifts to the survivors, and `503` with `Retry-After` is returned only when every worker is down. What is missing is the evidence: no 1-vs-N throughput or tail-latency measurement exists yet, and routing is round-robin only (least-inflight and EWMA are [Phase 4](ROADMAP.md#phase-4-multi-worker-serving)). Streaming through a worker returns 501. Multimodal requests are a separate planned milestone. Live-GPU validation has been performed on one NVIDIA GeForce RTX 3060 Laptop GPU with 6GB VRAM; no RTX 4060 or multi-GPU validation is claimed.
 
 ## Validated Evidence
 
@@ -39,10 +39,10 @@ The evidence below is a measured snapshot of the current serving path. The vLLM 
 | **Configuration as Code** | Implemented | YAML configuration with environment-variable overrides |
 | **Container Deployment** | Implemented | Docker CPU/GPU targets, Compose stack, and baseline Kubernetes manifests |
 | **Python Client SDK** | Implemented | Sync/async clients with deterministic streaming cleanup |
-| **Gateway/Worker Split** | Partial | Inference runs in a separate `role: worker` process reached over HTTP; one worker only, and streaming through a worker returns 501 |
-| **Worker Registry & Health** | Planned | Worker registration, health checks, and failure isolation |
-| **Latency-Aware Routing** | Planned | Round-robin, least-inflight, and EWMA-latency routing strategies |
-| **Circuit Breaking & Recovery** | Planned | Trip on unhealthy workers, drain, and rejoin on recovery |
+| **Gateway/Worker Split** | Partial | Inference runs in separate `role: worker` processes reached over HTTP; streaming through a worker returns 501 |
+| **Worker Registry & Health** | Implemented | Static registry with background `/health` probing, threshold-based removal, and automatic rejoin on recovery |
+| **Latency-Aware Routing** | Partial | Round-robin across healthy workers; least-inflight and EWMA are not implemented |
+| **Circuit Breaking & Recovery** | Partial | Failing workers leave rotation and rejoin after sustained health; connection failures retry on another worker |
 
 ---
 
@@ -66,20 +66,20 @@ flowchart LR
     Local --> VLLM[vLLM]
     Local --> SGLang[SGLang]
 
-    Batcher --> Remote[RemoteBackend / HTTP]
+    Batcher --> Remote[RemoteBackend]
+    Remote --> Registry[Registry: round-robin over healthy]
+    Registry --> W1[Worker 1]
+    Registry --> W2[Worker N]
+    HC[Health checker] -. probes /health .-> W1
+    HC -. probes /health .-> W2
+    HC --> Registry
 
-    subgraph WK[Worker process]
-        Remote --> WAPI["/internal/generate"]
-        WAPI --> WEngine[Engine: vLLM or SGLang]
-    end
+    W1 --> WEngine[Engine: vLLM or SGLang]
 
-    Remote -. not implemented .-> Router[Router: round-robin / least-inflight / EWMA]
-    Router -. not implemented .-> Registry[Worker registry + health checks]
-    Registry -. not implemented .-> W2[Workers 2..N]
-    Router -. not implemented .-> CB[Circuit breaker / recovery]
+    Registry -. not implemented .-> LI[least-inflight / EWMA routing]
 
     GW --> Obs[Metrics / Logs / Traces]
-    WK --> Obs
+    W1 --> Obs
 ```
 
 The boundary: the gateway owns admission control, deduplication, caching, and observability; a worker owns one engine instance and nothing else. Because `RemoteBackend` implements the same `InferenceBackend` protocol as the local engines, the batcher does not know whether inference is local or remote — adding the worker hop required no change to it.
@@ -174,13 +174,30 @@ Or with Compose:
 docker compose --profile split up
 ```
 
-Current limits of split mode:
+Multiple workers, with failover:
 
-- **One worker.** Configuring more than one endpoint is rejected at startup rather than silently ignored; routing across workers needs the registry and health checks that come next.
+```bash
+# Two workers
+VGATE_ROLE=worker VGATE_SERVER__PORT=8001 VGATE_DRY_RUN=true python main.py
+VGATE_ROLE=worker VGATE_SERVER__PORT=8002 VGATE_DRY_RUN=true python main.py
+
+# Gateway routing across both
+VGATE_ROLE=gateway VGATE_SERVER__PORT=8000 \
+  VGATE_WORKER__ENDPOINTS='["http://127.0.0.1:8001","http://127.0.0.1:8002"]' python main.py
+
+# Per-worker health is visible on /stats
+curl -s http://localhost:8000/stats | jq .workers
+```
+
+Behavior of split mode:
+
+- **Round-robin across healthy workers.** Least-inflight and EWMA routing are not implemented.
+- **Failover works without dropping requests.** Killing a worker removes it from rotation; traffic continues on the survivors. Only when *every* worker is down do requests get `503` with `Retry-After`.
+- **Retries are limited to connection failures.** A worker that refuses a connection never received the request, so another worker takes it. A worker that times out may already be generating, so that is *not* retried — one client request must not cost two GPU generations.
+- **Recovery is automatic.** A background probe polls `/health` independently of traffic, so a restarted worker rejoins even while the gateway is idle.
 - **No streaming.** `stream: true` returns `501` before any SSE bytes are sent, instead of a `200` followed by an in-band error.
-- **No health checking.** If the worker is down, requests fail with `500` and a `worker unreachable` detail. The gateway itself stays up, and cached responses continue to be served.
 - The worker exposes only `/internal/generate`, `/health`, and `/metrics`; client-facing routes return `404` in the worker role.
-- With `security.enabled`, set `worker.api_key` on the gateway — `/internal/generate` is not an exempt path, so it requires the same bearer token as any other route.
+- With `security.enabled`, set `worker.api_key` on the gateway — `/internal/generate` is not an exempt path, so it requires the same bearer token as any other route (health probes send it too).
 
 ### Option 3: Isolated SGLang Environment (Recommended)
 

--- a/config.yaml
+++ b/config.yaml
@@ -23,19 +23,33 @@ server:
 # Remote inference workers, read by the gateway role / 远程推理 worker
 #
 # Leave `endpoints` empty to keep inference in the gateway process (the
-# single-process default). Listing an endpoint moves inference to a separate
-# worker, and the gateway stops loading a model entirely.
+# single-process default). Listing endpoints moves inference to separate
+# worker processes, and the gateway stops loading a model entirely.
 #
-# Streaming is not supported through a worker yet: stream=true returns 501.
-# Exactly one endpoint is supported for now; routing across several workers
-# needs a registry and health checks, which are not implemented yet.
+# Requests are routed round-robin across healthy workers. A worker that
+# refuses a connection is retried on another worker; a worker that times out
+# is not, because it may already be generating and retrying would double the
+# GPU cost of one request.
+#
+# Streaming is not supported through workers yet: stream=true returns 501.
 worker:
   endpoints: []
-  # endpoints: ["http://127.0.0.1:8001"]
+  # endpoints: ["http://127.0.0.1:8001", "http://127.0.0.1:8002"]
   timeout_seconds: 120.0
   connect_timeout_seconds: 5.0
-  # Sent as `Authorization: Bearer <key>` to the worker. Required when the
-  # worker runs with security.enabled, since /internal/generate is not exempt.
+
+  # Background probing of /health. Runs independently of request traffic, so
+  # a recovered worker rejoins even while the gateway is idle.
+  health_check_interval_seconds: 5.0
+  health_check_timeout_seconds: 2.0
+  # Consecutive failures before a worker leaves rotation, and consecutive
+  # successes before it returns. Above 1 so a single blip does not flap it.
+  failure_threshold: 2
+  success_threshold: 2
+
+  # Sent as `Authorization: Bearer <key>` to the worker, on both generate
+  # calls and health probes. Required when the worker runs with
+  # security.enabled, since /internal/generate is not exempt.
   # api_key: "sk-vgate-worker-xxxxx"
 
 # Model configuration / 模型配置

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,13 +46,13 @@ services:
       - cpu
 
   # ---------------------------------------------------------------------------
-  # Split mode — gateway and inference worker as separate processes
+  # Split mode — gateway and inference workers as separate processes
   # docker compose --profile split up
   #
   # The gateway holds no model: it owns admission, batching, caching, and
-  # observability, and forwards inference to the worker over HTTP. Runs on the
-  # CPU image with a dry-run worker so the topology can be exercised without a
-  # GPU. Streaming is not supported through a worker yet and returns 501.
+  # observability, and routes inference to workers over HTTP. Runs on the CPU
+  # image with dry-run workers so the topology can be exercised without a GPU.
+  # Streaming is not supported through a worker yet and returns 501.
   # ---------------------------------------------------------------------------
   vgate-gateway:
     build:
@@ -64,14 +64,19 @@ services:
     environment:
       - VGATE_ROLE=gateway
       - VGATE_CONFIG_PATH=/app/config.yaml
-      - VGATE_WORKER__ENDPOINTS=["http://vgate-worker:8000"]
+      # Both workers are listed explicitly. Compose's `--scale` gives replicas
+      # a shared DNS name rather than individual ones, which a static registry
+      # cannot address one by one.
+      - VGATE_WORKER__ENDPOINTS=["http://vgate-worker-1:8000","http://vgate-worker-2:8000"]
     depends_on:
-      vgate-worker:
+      vgate-worker-1:
+        condition: service_healthy
+      vgate-worker-2:
         condition: service_healthy
     profiles:
       - split
 
-  vgate-worker:
+  vgate-worker-1: &vgate-worker
     build:
       context: .
       target: vgate-cpu
@@ -80,7 +85,7 @@ services:
       - VGATE_ROLE=worker
       - VGATE_DRY_RUN=true
       - VGATE_CONFIG_PATH=/app/config.yaml
-    # Deliberately no published port: the worker is reachable only from the
+    # Deliberately no published port: workers are reachable only from the
     # gateway on the compose network, not from the host.
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
@@ -88,6 +93,13 @@ services:
       timeout: 3s
       retries: 10
       start_period: 10s
+    profiles:
+      - split
+
+  # Identical to worker-1. Stop it (`docker compose stop vgate-worker-2`) to
+  # watch the gateway remove it from rotation and keep serving.
+  vgate-worker-2:
+    <<: *vgate-worker
     profiles:
       - split
 

--- a/main.py
+++ b/main.py
@@ -34,6 +34,8 @@ from vgate.metrics import (
 )
 from vgate.security import SecurityMiddleware
 from vgate.tracing import init_tracing, shutdown_tracing, get_current_trace_id
+from vgate.health_checker import WorkerHealthChecker
+from vgate.worker_registry import NoHealthyWorkersError
 from vgate import worker_api
 
 # Prometheus client for metrics endpoint
@@ -56,12 +58,13 @@ IS_WORKER = config.role == "worker"
 # Lazy initialization - will be set in lifespan
 engine = None
 batcher = None
+health_checker = None
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Lifecycle manager for startup/shutdown."""
-    global engine, batcher
+    global engine, batcher, health_checker
 
     # Initialize tracing before other components
     init_tracing(config)
@@ -100,6 +103,17 @@ async def lifespan(app: FastAPI):
     # Initialize the RequestBatcher (uses config defaults)
     batcher = RequestBatcher(engine=engine)
 
+    # Probe workers in the background so recovery is noticed on an idle
+    # gateway too, not only when a request happens to retry a dead worker.
+    if engine.is_remote:
+        health_checker = WorkerHealthChecker(
+            registry=engine.backend.registry,
+            interval_seconds=config.worker.health_check_interval_seconds,
+            timeout_seconds=config.worker.health_check_timeout_seconds,
+            api_key=config.worker.api_key,
+        )
+        await health_checker.start()
+
     # Startup: start the batcher
     await batcher.start()
     app_logger.info(
@@ -128,6 +142,12 @@ async def lifespan(app: FastAPI):
     yield
     # Shutdown: stop the batcher
     await batcher.stop()
+    if health_checker is not None:
+        await health_checker.stop()
+    # getattr: shutdown must not raise on an unexpected engine object, or the
+    # real reason the process is going down gets masked by an AttributeError.
+    if getattr(engine, "is_remote", False):
+        engine.backend.shutdown()
     shutdown_tracing()
     app_logger.info("V-Gate stopped")
 
@@ -444,6 +464,20 @@ async def create_chat_completion(request: ChatCompletionRequest):
                 "total_tokens": response.get("total_tokens", 0) + response.get("prompt_tokens", 0),
             },
         }
+    except NoHealthyWorkersError as e:
+        # Every worker is out of rotation. This is capacity unavailable, not a
+        # bad request or a gateway bug, so it is a 503 with Retry-After rather
+        # than a 500 — the distinction is what tells a client to back off and
+        # retry instead of treating the request as poison.
+        app_logger.error(
+            "No healthy workers",
+            extra={"extra_data": {"error": str(e)}}
+        )
+        raise HTTPException(
+            status_code=503,
+            detail=str(e),
+            headers={"Retry-After": "5"},
+        )
     except Exception as e:
         app_logger.error(
             "Chat completion error",
@@ -504,7 +538,7 @@ async def get_stats():
     Useful for monitoring and debugging.
     """
     metrics = batcher.get_metrics()
-    return {
+    stats = {
         "batcher": {
             "total_requests": metrics["total_requests"],
             "total_batches": metrics["total_batches"],
@@ -537,6 +571,13 @@ async def get_stats():
         },
         "version": APP_VERSION,
     }
+
+    # Only present when inference is remote; an in-process gateway has no
+    # workers to report on.
+    if engine is not None and engine.is_remote:
+        stats["workers"] = engine.backend.registry.snapshot()
+
+    return stats
 
 
 class BenchmarkRequest(BaseModel):

--- a/tests/test_worker_registry.py
+++ b/tests/test_worker_registry.py
@@ -1,0 +1,373 @@
+# Copyright 2025 the V-Gate authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for worker registry, health probing, and routing/retry behavior."""
+
+import asyncio
+import threading
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vgate.backends.remote_backend import RemoteBackend, RemoteInferenceError
+from vgate.config import WorkerConfig
+from vgate.health_checker import WorkerHealthChecker
+from vgate.worker_registry import NoHealthyWorkersError, WorkerRegistry
+
+THREE = ["http://a:8001", "http://b:8001", "http://c:8001"]
+
+
+# --------------------------------------------------------------------------
+# Registry: selection
+# --------------------------------------------------------------------------
+
+def test_registry_requires_endpoints():
+    with pytest.raises(ValueError, match="at least one endpoint"):
+        WorkerRegistry([])
+
+
+def test_pick_cycles_round_robin():
+    reg = WorkerRegistry(THREE)
+    assert [reg.pick() for _ in range(6)] == THREE + THREE
+
+
+def test_pick_skips_unhealthy():
+    reg = WorkerRegistry(THREE, failure_threshold=1)
+    reg.record_failure("http://b:8001")
+    picks = {reg.pick() for _ in range(6)}
+    assert picks == {"http://a:8001", "http://c:8001"}
+
+
+def test_pick_honors_exclude():
+    reg = WorkerRegistry(THREE)
+    first = reg.pick()
+    second = reg.pick(exclude={first})
+    assert second != first
+
+
+def test_pick_raises_when_all_unhealthy():
+    reg = WorkerRegistry(THREE, failure_threshold=1)
+    for ep in THREE:
+        reg.record_failure(ep)
+    assert reg.has_healthy() is False
+    with pytest.raises(NoHealthyWorkersError):
+        reg.pick()
+
+
+def test_pick_raises_when_all_excluded():
+    reg = WorkerRegistry(THREE)
+    with pytest.raises(NoHealthyWorkersError):
+        reg.pick(exclude=set(THREE))
+
+
+# --------------------------------------------------------------------------
+# Registry: health transitions
+# --------------------------------------------------------------------------
+
+def test_failure_threshold_tolerates_a_single_blip():
+    reg = WorkerRegistry(THREE, failure_threshold=2)
+    reg.record_failure("http://a:8001")
+    assert "http://a:8001" in reg.healthy_endpoints()
+    reg.record_failure("http://a:8001")
+    assert "http://a:8001" not in reg.healthy_endpoints()
+
+
+def test_success_resets_failure_streak():
+    reg = WorkerRegistry(THREE, failure_threshold=2)
+    reg.record_failure("http://a:8001")
+    reg.record_success("http://a:8001")
+    reg.record_failure("http://a:8001")
+    # The streak restarted, so one more failure should not be enough.
+    assert "http://a:8001" in reg.healthy_endpoints()
+
+
+def test_recovery_requires_sustained_success():
+    reg = WorkerRegistry(THREE, failure_threshold=1, success_threshold=2)
+    reg.record_failure("http://a:8001")
+    assert "http://a:8001" not in reg.healthy_endpoints()
+
+    reg.record_success("http://a:8001")
+    assert "http://a:8001" not in reg.healthy_endpoints(), "one probe should not restore"
+
+    reg.record_success("http://a:8001")
+    assert "http://a:8001" in reg.healthy_endpoints()
+
+
+def test_failure_during_recovery_restarts_the_count():
+    reg = WorkerRegistry(THREE, failure_threshold=1, success_threshold=2)
+    reg.record_failure("http://a:8001")
+    reg.record_success("http://a:8001")
+    reg.record_failure("http://a:8001")
+    reg.record_success("http://a:8001")
+    assert "http://a:8001" not in reg.healthy_endpoints()
+
+
+def test_unknown_endpoint_is_ignored():
+    reg = WorkerRegistry(THREE)
+    reg.record_failure("http://not-registered:9999")
+    reg.record_success("http://not-registered:9999")
+    assert reg.healthy_endpoints() == THREE
+
+
+def test_snapshot_reports_per_worker_state():
+    reg = WorkerRegistry(THREE, failure_threshold=1)
+    reg.record_failure("http://b:8001")
+    snap = {s["endpoint"]: s for s in reg.snapshot()}
+    assert snap["http://b:8001"]["healthy"] is False
+    assert snap["http://b:8001"]["total_failures"] == 1
+    assert snap["http://a:8001"]["healthy"] is True
+
+
+def test_registry_is_thread_safe():
+    """pick() runs in the batcher thread pool while probes run on the loop."""
+    reg = WorkerRegistry(THREE)
+    errors = []
+
+    def hammer():
+        try:
+            for _ in range(500):
+                reg.pick()
+                reg.record_success("http://a:8001")
+                reg.record_failure("http://b:8001")
+        except Exception as exc:  # noqa: BLE001 - surfacing any race
+            errors.append(exc)
+
+    threads = [threading.Thread(target=hammer) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert errors == []
+
+
+# --------------------------------------------------------------------------
+# Retry policy
+# --------------------------------------------------------------------------
+
+def _backend_with_handler(handler, endpoints=None, **kwargs) -> RemoteBackend:
+    """RemoteBackend whose transport is a scripted MockTransport."""
+    cfg = WorkerConfig(endpoints=endpoints or ["http://a:8001", "http://b:8001"], **kwargs)
+    backend = RemoteBackend(cfg)
+    backend._client.close()
+    backend._client = httpx.Client(transport=httpx.MockTransport(handler))
+    return backend
+
+
+OK_BODY = {"results": [{"text": "ok", "token_ids": [], "num_tokens": 1, "metrics": {}}]}
+
+
+def test_connect_error_retries_on_another_worker():
+    seen = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        if "a:8001" in str(request.url):
+            raise httpx.ConnectError("refused", request=request)
+        return httpx.Response(200, json=OK_BODY)
+
+    backend = _backend_with_handler(handler)
+    try:
+        results = backend.generate(["x"], {"temperature": 0.7, "top_p": 0.9, "max_tokens": 4})
+    finally:
+        backend.shutdown()
+
+    assert results == OK_BODY["results"]
+    assert len(seen) == 2, "should have tried the second worker"
+    assert "b:8001" in seen[-1]
+
+
+def test_timeout_does_not_retry():
+    """A timed-out worker may already be generating; retrying doubles GPU cost."""
+    seen = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        raise httpx.ReadTimeout("too slow", request=request)
+
+    backend = _backend_with_handler(handler)
+    try:
+        with pytest.raises(RemoteInferenceError, match="mid-request"):
+            backend.generate(["x"], {"temperature": 0.7, "top_p": 0.9, "max_tokens": 4})
+    finally:
+        backend.shutdown()
+
+    assert len(seen) == 1, "timeout must not be retried elsewhere"
+
+
+def test_http_error_does_not_retry():
+    """The worker received and rejected it; another worker would too."""
+    seen = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        return httpx.Response(500, json={"detail": "boom"})
+
+    backend = _backend_with_handler(handler)
+    try:
+        with pytest.raises(RemoteInferenceError, match="returned 500"):
+            backend.generate(["x"], {"temperature": 0.7, "top_p": 0.9, "max_tokens": 4})
+    finally:
+        backend.shutdown()
+
+    assert len(seen) == 1
+
+
+def test_all_workers_refusing_raises_no_healthy_workers():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused", request=request)
+
+    backend = _backend_with_handler(handler)
+    try:
+        with pytest.raises(NoHealthyWorkersError):
+            backend.generate(["x"], {"temperature": 0.7, "top_p": 0.9, "max_tokens": 4})
+    finally:
+        backend.shutdown()
+
+
+def test_retry_count_is_bounded_by_worker_count():
+    attempts = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts.append(str(request.url))
+        raise httpx.ConnectError("refused", request=request)
+
+    backend = _backend_with_handler(handler, endpoints=THREE)
+    try:
+        with pytest.raises(NoHealthyWorkersError):
+            backend.generate(["x"], {"temperature": 0.7, "top_p": 0.9, "max_tokens": 4})
+    finally:
+        backend.shutdown()
+
+    assert len(attempts) == 3, "each worker tried exactly once"
+
+
+def test_success_marks_worker_healthy_again():
+    state = {"fail": True}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if state["fail"]:
+            raise httpx.ConnectError("refused", request=request)
+        return httpx.Response(200, json=OK_BODY)
+
+    backend = _backend_with_handler(
+        handler, endpoints=["http://a:8001"], failure_threshold=1, success_threshold=1
+    )
+    try:
+        with pytest.raises(NoHealthyWorkersError):
+            backend.generate(["x"], {"temperature": 0.7, "top_p": 0.9, "max_tokens": 4})
+        assert backend.registry.has_healthy() is False
+
+        # Registry-level recovery, as the health checker would report it.
+        state["fail"] = False
+        backend.registry.record_success("http://a:8001")
+        assert backend.registry.has_healthy() is True
+
+        results = backend.generate(["x"], {"temperature": 0.7, "top_p": 0.9, "max_tokens": 4})
+        assert results == OK_BODY["results"]
+    finally:
+        backend.shutdown()
+
+
+# --------------------------------------------------------------------------
+# Health checker
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_probe_marks_failing_worker_unhealthy():
+    reg = WorkerRegistry(["http://a:8001"], failure_threshold=1)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    checker = WorkerHealthChecker(reg, interval_seconds=0.01, timeout_seconds=0.1)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await checker.probe_once(client)
+
+    assert reg.has_healthy() is False
+
+
+@pytest.mark.asyncio
+async def test_probe_restores_recovered_worker():
+    reg = WorkerRegistry(["http://a:8001"], failure_threshold=1, success_threshold=1)
+    reg.record_failure("http://a:8001")
+    assert reg.has_healthy() is False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/health"
+        return httpx.Response(200, json={"status": "ok"})
+
+    checker = WorkerHealthChecker(reg, interval_seconds=0.01, timeout_seconds=0.1)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await checker.probe_once(client)
+
+    assert reg.has_healthy() is True
+
+
+@pytest.mark.asyncio
+async def test_probe_treats_connection_error_as_unhealthy():
+    reg = WorkerRegistry(["http://a:8001"], failure_threshold=1)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused", request=request)
+
+    checker = WorkerHealthChecker(reg, interval_seconds=0.01, timeout_seconds=0.1)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await checker.probe_once(client)
+
+    assert reg.has_healthy() is False
+
+
+@pytest.mark.asyncio
+async def test_checker_loop_probes_and_stops_cleanly():
+    """The polling loop runs against a mock transport, not the real network."""
+    probes = []
+    reg = WorkerRegistry(["http://a:8001"], failure_threshold=1)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        probes.append(str(request.url))
+        return httpx.Response(500)
+
+    checker = WorkerHealthChecker(
+        reg,
+        interval_seconds=0.01,
+        timeout_seconds=0.1,
+        transport=httpx.MockTransport(handler),
+    )
+    await checker.start()
+    await asyncio.sleep(0.08)
+    await checker.stop()
+
+    assert checker._task is None
+    assert probes, "loop should have probed at least once"
+    assert reg.has_healthy() is False, "repeated 500s should remove the worker"
+
+
+@pytest.mark.asyncio
+async def test_checker_sends_api_key():
+    seen = {}
+    reg = WorkerRegistry(["http://a:8001"])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["auth"] = request.headers.get("Authorization")
+        return httpx.Response(200)
+
+    checker = WorkerHealthChecker(reg, api_key="sk-probe")
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), headers=checker._headers
+    ) as client:
+        await checker.probe_once(client)
+
+    assert seen["auth"] == "Bearer sk-probe"

--- a/tests/test_worker_split.py
+++ b/tests/test_worker_split.py
@@ -32,6 +32,7 @@ from vgate.backends.remote_backend import RemoteBackend, RemoteInferenceError
 from vgate.batcher import RequestBatcher
 from vgate.config import VGateConfig, WorkerConfig
 from vgate.engine import _create_backend
+from vgate.worker_registry import NoHealthyWorkersError, WorkerRegistry
 from vgate import worker_api
 
 
@@ -79,11 +80,13 @@ def test_remote_backend_satisfies_protocol():
     backend.shutdown()
 
 
-def test_remote_backend_rejects_multiple_endpoints():
-    # Multi-worker routing is not implemented yet; failing loudly beats
-    # silently using only the first endpoint.
-    with pytest.raises(ValueError, match="one worker endpoint"):
-        RemoteBackend(WorkerConfig(endpoints=["http://a:8001", "http://b:8001"]))
+def test_remote_backend_accepts_multiple_endpoints():
+    backend = RemoteBackend(WorkerConfig(endpoints=["http://a:8001", "http://b:8001"]))
+    try:
+        assert backend.registry.endpoints() == ["http://a:8001", "http://b:8001"]
+        assert backend.registry.healthy_endpoints() == ["http://a:8001", "http://b:8001"]
+    finally:
+        backend.shutdown()
 
 
 def test_remote_backend_requires_an_endpoint():
@@ -177,12 +180,14 @@ def test_remote_backend_forwards_generate_to_worker():
     assert results[0]["num_tokens"] == 8
 
 
-def test_remote_backend_raises_when_worker_unreachable():
+def test_remote_backend_raises_when_only_worker_unreachable():
+    # With every worker exhausted the error is NoHealthyWorkersError, which the
+    # gateway maps to 503 rather than 500.
     backend = RemoteBackend(
         WorkerConfig(endpoints=["http://127.0.0.1:1"], connect_timeout_seconds=0.1)
     )
     try:
-        with pytest.raises(RemoteInferenceError, match="unreachable"):
+        with pytest.raises(NoHealthyWorkersError):
             backend.generate(["ping"], {"temperature": 0.7, "top_p": 0.9, "max_tokens": 4})
     finally:
         backend.shutdown()
@@ -308,8 +313,11 @@ async def test_remote_backend_streaming_raises_not_implemented():
 # --------------------------------------------------------------------------
 
 class _Engine:
-    def __init__(self, backend):
+    """Stand-in for VGateEngine, matching the attributes main.py reads."""
+
+    def __init__(self, backend, is_remote: bool = False):
         self.backend = backend
+        self.is_remote = is_remote
 
 
 def test_batcher_serializes_local_backends():

--- a/vgate/backends/remote_backend.py
+++ b/vgate/backends/remote_backend.py
@@ -25,13 +25,18 @@ it through run_in_executor, so a blocking HTTP call there does not block the
 event loop.
 """
 
-from typing import Any, AsyncIterator, Dict, List
+import time
+from typing import Any, AsyncIterator, Dict, List, Optional
 
 import httpx
 
 from vgate.config import ModelConfig, WorkerConfig
 from vgate.logging_config import get_logger
+from vgate.metrics import (
+    WORKER_LATENCY, WORKER_REQUESTS, WORKER_RETRIES
+)
 from vgate.tracing import get_tracer
+from vgate.worker_registry import NoHealthyWorkersError, WorkerRegistry
 
 logger = get_logger("vgate.backends.remote")
 tracer = get_tracer("vgate.backends.remote")
@@ -56,20 +61,16 @@ class RemoteBackend:
     # 200 followed by an in-band error event.
     supports_streaming = False
 
-    def __init__(self, worker_config: WorkerConfig):
+    def __init__(self, worker_config: WorkerConfig, registry: Optional[WorkerRegistry] = None):
         if not worker_config.endpoints:
             raise ValueError("RemoteBackend requires at least one worker endpoint")
 
         self.config = worker_config
-        # PR1 targets a single worker. Routing across several endpoints, with a
-        # registry and health checks, is the next change; until then an extra
-        # endpoint would be silently ignored, so refuse it explicitly.
-        if len(worker_config.endpoints) > 1:
-            raise ValueError(
-                "RemoteBackend currently supports exactly one worker endpoint; "
-                f"got {len(worker_config.endpoints)}. Multi-worker routing is not implemented yet."
-            )
-        self.endpoint = worker_config.endpoints[0]
+        self.registry = registry or WorkerRegistry(
+            worker_config.endpoints,
+            failure_threshold=worker_config.failure_threshold,
+            success_threshold=worker_config.success_threshold,
+        )
 
         headers = {}
         if worker_config.api_key:
@@ -85,7 +86,7 @@ class RemoteBackend:
         logger.info(
             "Remote backend initialized",
             extra={"extra_data": {
-                "endpoint": self.endpoint,
+                "endpoints": worker_config.endpoints,
                 "timeout_seconds": worker_config.timeout_seconds,
                 "authenticated": bool(worker_config.api_key),
             }}
@@ -104,38 +105,97 @@ class RemoteBackend:
     def generate(
         self, prompts: List[str], sampling_params: Any
     ) -> List[Dict[str, Any]]:
+        """
+        Send a batch to a healthy worker, retrying on connection failures only.
+
+        Retry policy is deliberately narrow, and keyed on what the worker could
+        already have started doing:
+
+        - ConnectError: nothing was delivered, so another worker can safely
+          take the request.
+        - Timeout: the worker may be mid-generation. Retrying would double GPU
+          cost for one client request, so this fails instead.
+        - Non-200: the worker received and rejected the request. Another worker
+          would most likely reject it the same way.
+        """
         with tracer.start_as_current_span("remote.generate") as span:
             span.set_attribute("num_prompts", len(prompts))
-            span.set_attribute("endpoint", self.endpoint)
 
-            try:
-                response = self._client.post(
-                    f"{self.endpoint}/internal/generate",
-                    json={"prompts": prompts, "sampling_params": sampling_params},
-                )
-            except httpx.RequestError as exc:
-                span.set_attribute("error", True)
-                raise RemoteInferenceError(
-                    f"worker at {self.endpoint} unreachable: {type(exc).__name__}"
-                ) from exc
+            tried: set = set()
+            last_connect_error: Optional[Exception] = None
 
-            if response.status_code != 200:
-                span.set_attribute("error", True)
-                # Worker error bodies may echo prompt text; keep only a bounded
-                # prefix out of the exception message.
-                raise RemoteInferenceError(
-                    f"worker at {self.endpoint} returned {response.status_code}: "
-                    f"{response.text[:200]}"
-                )
+            # Bounded by the number of workers: each attempt excludes the ones
+            # already tried, so this cannot spin.
+            for attempt in range(len(self.registry.endpoints())):
+                try:
+                    endpoint = self.registry.pick(exclude=tried)
+                except NoHealthyWorkersError:
+                    break
 
-            payload = response.json()
-            results = payload.get("results")
-            if not isinstance(results, list) or len(results) != len(prompts):
-                raise RemoteInferenceError(
-                    f"worker at {self.endpoint} returned {len(results) if isinstance(results, list) else 'no'} "
-                    f"results for {len(prompts)} prompts"
-                )
-            return results
+                if attempt > 0:
+                    WORKER_RETRIES.labels(worker=endpoint).inc()
+                    span.set_attribute("retried", True)
+
+                started = time.perf_counter()
+                try:
+                    response = self._client.post(
+                        f"{endpoint}/internal/generate",
+                        json={"prompts": prompts, "sampling_params": sampling_params},
+                    )
+                except httpx.ConnectError as exc:
+                    # Never delivered — safe to move on to another worker.
+                    self.registry.record_failure(endpoint)
+                    WORKER_REQUESTS.labels(worker=endpoint, outcome="connect_error").inc()
+                    tried.add(endpoint)
+                    last_connect_error = exc
+                    continue
+                except httpx.RequestError as exc:
+                    # Timeouts and read errors land here: the worker may already
+                    # be generating, so this is not retried elsewhere.
+                    self.registry.record_failure(endpoint)
+                    WORKER_REQUESTS.labels(worker=endpoint, outcome="request_error").inc()
+                    span.set_attribute("error", True)
+                    raise RemoteInferenceError(
+                        f"worker at {endpoint} failed mid-request: {type(exc).__name__}"
+                    ) from exc
+                finally:
+                    WORKER_LATENCY.labels(worker=endpoint).observe(time.perf_counter() - started)
+
+                if response.status_code != 200:
+                    self.registry.record_failure(endpoint)
+                    WORKER_REQUESTS.labels(worker=endpoint, outcome="http_error").inc()
+                    span.set_attribute("error", True)
+                    # Worker error bodies may echo prompt text; keep only a
+                    # bounded prefix out of the exception message.
+                    raise RemoteInferenceError(
+                        f"worker at {endpoint} returned {response.status_code}: "
+                        f"{response.text[:200]}"
+                    )
+
+                payload = response.json()
+                results = payload.get("results")
+                if not isinstance(results, list) or len(results) != len(prompts):
+                    self.registry.record_failure(endpoint)
+                    WORKER_REQUESTS.labels(worker=endpoint, outcome="bad_response").inc()
+                    raise RemoteInferenceError(
+                        f"worker at {endpoint} returned "
+                        f"{len(results) if isinstance(results, list) else 'no'} "
+                        f"results for {len(prompts)} prompts"
+                    )
+
+                self.registry.record_success(endpoint)
+                WORKER_REQUESTS.labels(worker=endpoint, outcome="success").inc()
+                span.set_attribute("endpoint", endpoint)
+                return results
+
+            span.set_attribute("error", True)
+            detail = (
+                f"last error: {type(last_connect_error).__name__}"
+                if last_connect_error else "none reachable"
+            )
+            raise NoHealthyWorkersError(
+                f"no healthy worker served the request after {len(tried)} attempt(s); {detail}"
+            )
 
     async def stream_generate(
         self, prompt: str, sampling_params: Any

--- a/vgate/config.py
+++ b/vgate/config.py
@@ -53,6 +53,13 @@ class WorkerConfig(BaseModel):
     # when the first request arrives.
     timeout_seconds: float = 120.0
     connect_timeout_seconds: float = 5.0
+    # Health probing. Thresholds above 1 keep a single blip from taking a
+    # worker out of rotation, and require sustained recovery before it is
+    # trusted again.
+    health_check_interval_seconds: float = 5.0
+    health_check_timeout_seconds: float = 2.0
+    failure_threshold: int = 2
+    success_threshold: int = 2
     # Sent as `Authorization: Bearer <api_key>` to the worker. Needed when the
     # worker runs with security.enabled, since /internal/generate is not an
     # exempt path.

--- a/vgate/health_checker.py
+++ b/vgate/health_checker.py
@@ -1,0 +1,119 @@
+# Copyright 2025 the V-Gate authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Background health probing for worker endpoints.
+
+Probing runs alongside the failure signal that RemoteBackend records from real
+requests. Both feed the same registry, and they answer different questions:
+request failures notice a dead worker immediately but only when traffic is
+flowing, while probes notice recovery on an idle gateway, where no request
+would ever retry the worker and let it back in.
+"""
+
+import asyncio
+from typing import Optional
+
+import httpx
+
+from vgate.logging_config import get_logger
+from vgate.worker_registry import WorkerRegistry
+
+logger = get_logger("vgate.health")
+
+
+class WorkerHealthChecker:
+    """Polls each worker's /health and reports the result to the registry."""
+
+    def __init__(
+        self,
+        registry: WorkerRegistry,
+        interval_seconds: float = 5.0,
+        timeout_seconds: float = 2.0,
+        api_key: Optional[str] = None,
+        transport: Optional[httpx.AsyncBaseTransport] = None,
+    ):
+        self.registry = registry
+        self.interval_seconds = interval_seconds
+        self.timeout_seconds = timeout_seconds
+        # Injectable so the polling loop can be exercised without real network
+        # calls; None means httpx picks its default transport.
+        self._transport = transport
+        self._task: Optional[asyncio.Task] = None
+        self._running = False
+
+        headers = {}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        self._headers = headers
+
+    async def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._loop())
+        logger.info(
+            "Worker health checker started",
+            extra={"extra_data": {
+                "workers": self.registry.endpoints(),
+                "interval_seconds": self.interval_seconds,
+            }}
+        )
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        logger.info("Worker health checker stopped")
+
+    async def _loop(self) -> None:
+        # A separate client from RemoteBackend's: probes must not queue behind
+        # in-flight generate calls, which can legitimately take minutes.
+        async with httpx.AsyncClient(
+            timeout=self.timeout_seconds,
+            headers=self._headers,
+            transport=self._transport,
+        ) as client:
+            while self._running:
+                await asyncio.sleep(self.interval_seconds)
+                if not self._running:
+                    break
+                await self.probe_once(client)
+
+    async def probe_once(self, client: httpx.AsyncClient) -> None:
+        """Probe every worker once, concurrently."""
+        endpoints = self.registry.endpoints()
+        results = await asyncio.gather(
+            *(self._probe(client, ep) for ep in endpoints),
+            return_exceptions=True,
+        )
+        for endpoint, healthy in zip(endpoints, results):
+            # gather with return_exceptions can hand back an exception object;
+            # anything that is not an explicit True counts as a failed probe.
+            if healthy is True:
+                self.registry.record_success(endpoint)
+            else:
+                self.registry.record_failure(endpoint)
+
+    async def _probe(self, client: httpx.AsyncClient, endpoint: str) -> bool:
+        try:
+            response = await client.get(f"{endpoint}/health")
+        except httpx.RequestError:
+            return False
+        return response.status_code == 200

--- a/vgate/metrics.py
+++ b/vgate/metrics.py
@@ -241,6 +241,50 @@ DEDUP_RATIO = _safe_metric(
 )
 
 
+# =============================================================================
+# Worker Routing Metrics
+# =============================================================================
+#
+# `worker` is the configured endpoint, which is bounded by config and does not
+# grow with traffic. No request-scoped value (prompt, request id, error text)
+# is used as a label.
+
+WORKER_HEALTHY = _safe_metric(
+    Gauge,
+    "vgate_worker_healthy",
+    "Whether a worker is currently in rotation (1) or removed (0)",
+    labelnames=["worker"]
+)
+
+WORKER_STATE_CHANGES = _safe_metric(
+    Counter,
+    "vgate_worker_state_changes_total",
+    "Worker health transitions",
+    labelnames=["worker", "transition"]
+)
+
+WORKER_REQUESTS = _safe_metric(
+    Counter,
+    "vgate_worker_requests_total",
+    "Requests dispatched to a worker by outcome",
+    labelnames=["worker", "outcome"]
+)
+
+WORKER_RETRIES = _safe_metric(
+    Counter,
+    "vgate_worker_retries_total",
+    "Requests retried on another worker after a connection failure",
+    labelnames=["worker"]
+)
+
+WORKER_LATENCY = _safe_metric(
+    Histogram,
+    "vgate_worker_latency_seconds",
+    "Time spent in a worker generate call",
+    labelnames=["worker"]
+)
+
+
 def init_app_info(version: str = "0.3.0", model: str = "unknown"):
     """Initialize application info metric."""
     APP_INFO.info({

--- a/vgate/worker_registry.py
+++ b/vgate/worker_registry.py
@@ -1,0 +1,184 @@
+# Copyright 2025 the V-Gate authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Worker registry and health tracking.
+
+State here is touched from two places at once: the background health-check
+task on the event loop, and RemoteBackend.generate() running in the batcher's
+thread pool. That rules out asyncio.Lock -- a threading.Lock is what actually
+protects the state across both.
+
+Membership is static (read from config). This registry tracks which of those
+known workers are currently usable, not which workers exist.
+"""
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from vgate.logging_config import get_logger
+from vgate.metrics import WORKER_HEALTHY, WORKER_STATE_CHANGES
+
+logger = get_logger("vgate.registry")
+
+
+@dataclass
+class WorkerState:
+    """Health bookkeeping for a single worker endpoint."""
+
+    endpoint: str
+    healthy: bool = True
+    consecutive_failures: int = 0
+    consecutive_successes: int = 0
+    last_change_at: float = field(default_factory=time.monotonic)
+    total_failures: int = 0
+
+
+class NoHealthyWorkersError(RuntimeError):
+    """Raised when every known worker is currently marked unhealthy."""
+
+
+class WorkerRegistry:
+    """
+    Tracks health of a fixed set of worker endpoints and picks one per request.
+
+    Workers start optimistically healthy so a gateway can serve traffic before
+    the first health probe completes; a worker that is actually down is
+    demoted by the first failed request or probe.
+    """
+
+    def __init__(
+        self,
+        endpoints: List[str],
+        failure_threshold: int = 2,
+        success_threshold: int = 2,
+    ):
+        if not endpoints:
+            raise ValueError("WorkerRegistry requires at least one endpoint")
+
+        self.failure_threshold = failure_threshold
+        self.success_threshold = success_threshold
+
+        self._lock = threading.Lock()
+        self._states = {ep: WorkerState(endpoint=ep) for ep in endpoints}
+        self._order = list(endpoints)
+        self._cursor = 0
+
+        for ep in endpoints:
+            WORKER_HEALTHY.labels(worker=ep).set(1)
+
+    # -- selection ---------------------------------------------------------
+
+    def pick(self, exclude: Optional[set] = None) -> str:
+        """
+        Return the next healthy endpoint, round-robin.
+
+        `exclude` lets a caller skip endpoints it has already tried within one
+        request, so a retry lands on a different worker instead of the one
+        that just refused the connection.
+        """
+        exclude = exclude or set()
+        with self._lock:
+            total = len(self._order)
+            for offset in range(total):
+                endpoint = self._order[(self._cursor + offset) % total]
+                if endpoint in exclude:
+                    continue
+                if self._states[endpoint].healthy:
+                    # Advance past the chosen worker so the next call starts
+                    # at the following one.
+                    self._cursor = (self._cursor + offset + 1) % total
+                    return endpoint
+
+        raise NoHealthyWorkersError(
+            f"no healthy worker available ({len(exclude)} excluded this request)"
+        )
+
+    # -- health transitions ------------------------------------------------
+
+    def record_failure(self, endpoint: str) -> None:
+        """
+        Count a failed interaction, demoting the worker at the threshold.
+
+        A threshold above 1 keeps one transient blip from taking a worker out
+        of rotation.
+        """
+        with self._lock:
+            state = self._states.get(endpoint)
+            if state is None:
+                return
+            state.total_failures += 1
+            state.consecutive_successes = 0
+            state.consecutive_failures += 1
+            if state.healthy and state.consecutive_failures >= self.failure_threshold:
+                state.healthy = False
+                state.last_change_at = time.monotonic()
+                self._on_change(endpoint, healthy=False)
+
+    def record_success(self, endpoint: str) -> None:
+        """Count a successful interaction, restoring the worker at the threshold."""
+        with self._lock:
+            state = self._states.get(endpoint)
+            if state is None:
+                return
+            state.consecutive_failures = 0
+            if state.healthy:
+                state.consecutive_successes = 0
+                return
+            state.consecutive_successes += 1
+            if state.consecutive_successes >= self.success_threshold:
+                state.healthy = True
+                state.last_change_at = time.monotonic()
+                self._on_change(endpoint, healthy=True)
+
+    def _on_change(self, endpoint: str, healthy: bool) -> None:
+        """Emit metrics and a log line for a health transition. Caller holds the lock."""
+        WORKER_HEALTHY.labels(worker=endpoint).set(1 if healthy else 0)
+        WORKER_STATE_CHANGES.labels(
+            worker=endpoint, transition="recovered" if healthy else "removed"
+        ).inc()
+        logger.warning(
+            "Worker %s" % ("recovered" if healthy else "removed from rotation"),
+            extra={"extra_data": {"worker": endpoint, "healthy": healthy}},
+        )
+
+    # -- introspection -----------------------------------------------------
+
+    def endpoints(self) -> List[str]:
+        return list(self._order)
+
+    def healthy_endpoints(self) -> List[str]:
+        with self._lock:
+            return [ep for ep in self._order if self._states[ep].healthy]
+
+    def has_healthy(self) -> bool:
+        with self._lock:
+            return any(self._states[ep].healthy for ep in self._order)
+
+    def snapshot(self) -> List[dict]:
+        """Per-worker health for /stats. Bounded, no per-request detail."""
+        with self._lock:
+            now = time.monotonic()
+            return [
+                {
+                    "endpoint": ep,
+                    "healthy": s.healthy,
+                    "consecutive_failures": s.consecutive_failures,
+                    "total_failures": s.total_failures,
+                    "seconds_in_state": round(now - s.last_change_at, 1),
+                }
+                for ep, s in ((e, self._states[e]) for e in self._order)
+            ]


### PR DESCRIPTION
Re-targets #36 onto `main`.

#36 was stacked with `feat/gateway-worker-split` as its base. #35 merged that base into `main` first, so when #36 merged afterwards it landed on the already-merged base branch instead of `main` — the code was never lost, but it never reached `main` either.

This PR merges `feat/gateway-worker-split` (now at the #36 merge commit) into `main`. The delta against `main` is exactly the PR2 change: **11 files, +966 / −87**, identical to what #36 contained.

No new code. See **#36** for the full rationale — retry policy keyed on what a worker could already have started, two independent health signals, threading vs asyncio locking in the registry, and 503-vs-500 semantics.

## Verification (unchanged from #36)

One gateway, two live workers: 8 requests split exactly 4/4; killing a worker left all 6 following requests at 200; restarting it rejoined through the health probe alone and traffic rebalanced 4/4; killing both returned 503 with `Retry-After` while the gateway stayed up.

`tests/` 212 passed, `vgate-client/tests/` 74 passed.

## Process note

Stacked PRs need the stack merged bottom-up, and the lower PR must not be merged until the upper one has been retargeted. Simpler for this repo: keep one PR in flight at a time against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)