### PR TITLE
feat: replace gateway batching with dedup, admission, and fan-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,20 @@ What survived from the old batcher, because it was never really about batching:
 - **Deduplication**, now stronger — identical concurrent requests coalesce onto one inference for as long as it is in flight, not merely if they landed in the same window.
 - **Admission control**, which is what `max_batch_size` now expresses.
 
-`max_wait_time_ms` is accepted and ignored; there is no window to wait for. The startup log reports the value it is ignoring. With an in-process engine (not safe to call concurrently) the effective concurrency is forced to 1 regardless of `max_batch_size`; the setting takes effect when the gateway forwards to remote workers.
+`max_wait_time_ms` is accepted and ignored; there is no window to wait for. The startup log reports the value it is ignoring.
+
+Concurrency is capped by what the backend declares. `VLLMBackend` and `RemoteBackend` allow concurrent calls — `AsyncLLMEngine` exists to serve them, and serializing it would leave the GPU decoding one sequence at a time with continuous batching switched off. `SGLangBackend` does not declare it, because that adapter has never been run against a live engine, so its calls stay serialized until that is measured rather than assumed.
+
+### What happens to a request whose caller gave up
+
+A `timeout` on the client side, or a disconnect, does not automatically kill the inference — other callers may be coalesced onto the same one. The rule depends on whether the work has been admitted:
+
+| State | On last caller leaving | Why |
+|---|---|---|
+| Queued, not yet admitted | **Cancelled** | Nothing has been spent, and it would otherwise hold an admission permit a live request could use |
+| Already running | **Runs to completion** | The backend call is in a thread and cannot be interrupted anyway; its result populates the cache, so finishing is cheaper than discarding it |
+
+Reclamation counts waiters rather than firing on the first departure, so one caller timing out never cancels work another is still waiting for. Cancellations are counted in `vgate_abandoned_inferences_total`.
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ The evidence below is a measured snapshot of the current serving path. The vLLM 
 | **OpenAI-Shaped Chat API** | Partial | Chat Completions request/response subset (`/v1/chat/completions`); not claimed as full drop-in OpenAI compatibility |
 | **Embeddings Endpoint** | Partial | `/v1/embeddings` currently returns a mock 1536-dimensional vector for API/client testing |
 | **Streaming Inference** | Partial | SSE streaming for dry-run and real vLLM; SGLang streaming is not implemented yet |
-| **Dynamic Micro-Batching** | Implemented | Aggregate queued non-streaming requests into static gateway batches |
-| **Engine-Native Scheduling** | Partial | vLLM uses `AsyncLLMEngine`; the gateway batcher has not yet been redefined as unified admission control |
+| **Admission Control & Dedup** | Implemented | Bounds concurrent inferences and coalesces identical in-flight requests onto one; the gateway no longer builds batches — engines do that internally |
+| **Engine-Native Scheduling** | Implemented | Batching is left to the engine's own continuous batching; the gateway does admission control and deduplication instead of building windows |
 | **Result Caching** | Implemented | In-memory LRU cache with batch-level deduplication for non-streaming requests |
 | **Backend Adapters** | Partial | Select vLLM or SGLang with `model.engine_type`; vLLM is live-GPU validated, while SGLang is currently unit-tested and non-streaming |
 | **Built-in Benchmarking** | Implemented | Concurrent load tools, report generation, and `/v1/benchmark` |
@@ -420,8 +420,8 @@ model:
   engine_type: "vllm"  # "vllm" or "sglang"
 
 batch:
-  max_batch_size: 8
-  max_wait_time_ms: 50.0
+  max_batch_size: 8       # max concurrent inferences (see note below)
+  max_wait_time_ms: 50.0  # deprecated, ignored
 
 cache:
   enabled: true
@@ -464,6 +464,26 @@ VGATE_MODEL__ENGINE_TYPE=vllm python main.py
 # Switch to SGLang backend
 VGATE_MODEL__ENGINE_TYPE=sglang python main.py
 ```
+
+### A note on `batch.max_batch_size`
+
+Its meaning changed, and an existing config file will keep loading while behaving differently — so it is worth stating plainly.
+
+**Before**: the gateway collected requests into a window (`max_batch_size` requests, or `max_wait_time_ms` elapsed) and handed the whole window to one backend call.
+
+**Now**: the gateway does not build batches. Each request calls the backend on its own, and `max_batch_size` bounds how many may do so at once.
+
+Two reasons for the change:
+
+1. **vLLM and SGLang already batch, and do it better.** They can admit a new request into a batch that is already decoding; a sealed Python-side window cannot. The gateway-side window was competing with the engine's own scheduler rather than helping it.
+2. **A sealed batch is routed as a unit.** Every request in it lands on the same worker regardless of that worker's load, which makes load-aware routing impossible. Routing needs one decision per request.
+
+What survived from the old batcher, because it was never really about batching:
+
+- **Deduplication**, now stronger — identical concurrent requests coalesce onto one inference for as long as it is in flight, not merely if they landed in the same window.
+- **Admission control**, which is what `max_batch_size` now expresses.
+
+`max_wait_time_ms` is accepted and ignored; there is no window to wait for. The startup log reports the value it is ignoring. With an in-process engine (not safe to call concurrently) the effective concurrency is forced to 1 regardless of `max_batch_size`; the setting takes effect when the gateway forwards to remote workers.
 
 ### Environment Variables
 
@@ -696,7 +716,7 @@ Prerequisites for distributing anything: a single node must fail predictably bef
 - [x] Add gateway-to-worker bearer authentication for a private cluster
 - [~] Add routing strategies — round-robin is implemented; least-inflight and EWMA latency are not
 - [~] Add worker circuit breakers, draining, and recovery on rejoin — failing workers leave rotation and rejoin after sustained health; there is no in-flight draining
-- [ ] Redefine `RequestBatcher` as dedup/admission/fan-out so routing decisions are per request rather than per batch
+- [x] Redefine `RequestBatcher` as dedup/admission/fan-out so routing decisions are per request rather than per batch
 - [ ] Measure 1-worker vs N-worker throughput, tail latency, and behavior under injected worker failure
 
 `[~]` marks partial items. Routing is currently decided once per batch, not per request, which is why least-inflight is not implemented yet: it would be choosing between workers on a signal it cannot act on at that granularity.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,9 +29,9 @@ What is implemented is an OpenAI-style LLM gateway with:
 Current gaps:
 
 - OpenAI API compatibility is still shallow. Streaming (`stream: true`, SSE) now works end-to-end for the dry-run backend and real vLLM (verified on GPU); SGLang still raises a clear `NotImplementedError` until its async engine path lands (Phase 2 task 8).
-- `RequestBatcher` still forms a static, sealed Python-side batch per window (queue drain, `max_batch_size`/`max_wait_time_ms`) before handing prompts to the backend — new requests still can't join an already-formed batch at that layer. Below that layer, `VLLMBackend` now submits each prompt as an independent `AsyncLLMEngine.generate()` call, so vLLM's own scheduler does get to interleave/continuously-batch them at the GPU level even though the Python-side batch above it is still static. Full task 9 (redefine `RequestBatcher` as dedup/admission/fan-out, not batch construction) is not done.
+- Streaming still bypasses `RequestBatcher` entirely (`_stream_chat_completion` calls the backend directly), so streamed requests get no cache lookup, no deduplication, and no admission control. Folding streaming into the same admission path is the remaining half of task 9.
 - Multi-worker serving runs but is unmeasured: the gateway routes round-robin across healthy workers with health-based failover, yet no 1-vs-N throughput or tail-latency evidence exists, and routing is not load-aware.
-- Routing granularity is per batch, not per request, because `RequestBatcher` still hands a whole batch to one backend call. This blocks least-inflight and EWMA routing.
+- Routing is per request now that `RequestBatcher` fans out, so least-inflight and EWMA are unblocked — but neither is implemented, and routing remains round-robin.
 - Streaming does not work through a remote worker; the gateway returns 501 rather than opening a stream it cannot serve.
 - Dry-run and single-GPU vLLM reports are checked in, but they predate parts of the current async serving path. A refreshed streaming baseline, repeat-run variance analysis, and 1-vs-N-worker evidence are still missing.
 - Cache is RAM-only. There is no persistent local disk cache layer, and cache value depends on process lifetime. This is an intentional, benchmark-gated decision (Phase 1.5), not an oversight — current traffic shows no L1 eviction pressure.
@@ -288,7 +288,7 @@ Task 5 (streaming metrics) is done: `vgate_stream_ttft_seconds`, `vgate_stream_t
 
 Known, intentional limitation: the streaming path in `main.py` (`_stream_chat_completion`) calls `engine.backend.stream_generate()` directly and bypasses `RequestBatcher` entirely — no cache lookup, no batch-level dedup, no admission control for streamed requests yet. That integration is task 9, not started.
 
-Not yet done: the SGLang async backend path (task 8) and redefining `RequestBatcher` (task 9).
+Task 9 is now half done: `RequestBatcher` has been redefined as dedup/admission/fan-out, so the non-streaming path gets per-request routing and in-flight coalescing. The streaming path still bypasses it entirely. Not yet done: the SGLang async backend path (task 8), and folding streaming into the same admission path.
 
 Priority: high.
 
@@ -406,7 +406,7 @@ Tasks:
 8. [ ] Add multi-worker benchmarks — **nothing is measured yet**; no 1-vs-N throughput or tail-latency numbers exist.
 9. [x] Add minimal gateway-to-worker authentication — bearer token on both generate calls and health probes; `/internal/generate` is not an exempt path.
 
-Blocking task 5's remaining strategies: routing is currently decided once per batch, because `RequestBatcher` still hands a whole batch to one `backend.generate()` call. Least-inflight and EWMA select between workers on per-request load, so they need Phase 2 task 9 (redefine `RequestBatcher` as dedup/admission/fan-out) first. Implementing them at batch granularity would produce a routing policy that cannot act on the signal it reads.
+Task 5's remaining strategies are now unblocked: `RequestBatcher` fans out, so each request is routed on its own and a load-aware policy can act on the signal it reads. Least-inflight needs per-worker in-flight counters; EWMA needs per-worker latency tracking with exponential decay. Neither is implemented.
 
 Retry semantics worth recording, since they are a design decision rather than a detail: a connection failure is retried on another worker because nothing was delivered; a timeout is not, because the worker may already be generating and retrying would spend two GPU generations on one client request; a non-200 is not, because another worker would most likely reject it identically.
 

--- a/config.yaml
+++ b/config.yaml
@@ -64,7 +64,26 @@ model:
 
 # Request batching / 请求批处理
 batch:
+  # Maximum concurrent inferences (admission control).
+  #
+  # NOTE: the meaning of this key changed. It used to size a batching window
+  # -- how many requests were collected before one backend call. The gateway
+  # no longer builds batches: each request calls the backend on its own, so
+  # a routing decision happens per request, and vLLM/SGLang do the actual
+  # batching internally (which they do better, since they can admit a request
+  # into a batch that is already decoding).
+  #
+  # The key is unchanged so existing configs keep loading, and the value
+  # still bounds how much work reaches the backend at once.
+  #
+  # With a backend that is not safe to call concurrently (the in-process
+  # vLLM/SGLang engines), the effective limit is forced to 1 regardless of
+  # this value. It takes effect when the gateway forwards to remote workers.
   max_batch_size: 8
+
+  # DEPRECATED and ignored. There is no batching window to wait for. Still
+  # accepted so existing configs do not fail to load; the startup log reports
+  # the value it is ignoring.
   max_wait_time_ms: 50.0
 
 # Result cache / 结果缓存

--- a/tests/test_batcher.py
+++ b/tests/test_batcher.py
@@ -23,7 +23,7 @@ import time
 from unittest.mock import MagicMock, patch
 from dataclasses import dataclass
 
-from vgate.batcher import RequestBatcher, BatchRequest
+from vgate.batcher import RequestBatcher
 
 
 class MockBackend:
@@ -61,6 +61,42 @@ class MockEngine:
         self.backend = MockBackend()
 
 
+class _SlowBackend:
+    """Backend with a controllable delay, for timeout/cancellation tests."""
+
+    def __init__(self, delay: float):
+        self.delay = delay
+        self.calls = 0
+
+    def create_sampling_params(self, temperature, top_p, max_tokens):
+        return {"temperature": temperature, "top_p": top_p, "max_tokens": max_tokens}
+
+    def generate(self, prompts, sampling_params):
+        import time as _t
+
+        self.calls += 1
+        _t.sleep(self.delay)
+        return [
+            {
+                "text": f"Response to: {p[:30]}",
+                "token_ids": list(range(10)),
+                "num_tokens": 10,
+                "metrics": {},
+            }
+            for p in prompts
+        ]
+
+    def shutdown(self):
+        pass
+
+
+class _EngineWith:
+    """Minimal engine wrapper around an arbitrary backend."""
+
+    def __init__(self, backend):
+        self.backend = backend
+
+
 @pytest.fixture
 def mock_engine():
     """Create a mock engine for testing."""
@@ -77,26 +113,6 @@ def batcher(mock_engine):
     )
 
 
-class TestBatchRequest:
-    """Tests for BatchRequest dataclass."""
-
-    def test_creation(self):
-        """Test BatchRequest can be created with required fields."""
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            req = BatchRequest(
-                prompt="Hello world",
-                max_tokens=100,
-            )
-            assert req.prompt == "Hello world"
-            assert req.max_tokens == 100
-            assert req.future is not None
-            assert req.created_at > 0
-        finally:
-            loop.close()
-
-
 class TestRequestBatcher:
     """Tests for RequestBatcher class."""
 
@@ -105,7 +121,9 @@ class TestRequestBatcher:
         """Test batcher can start and stop cleanly."""
         await batcher.start()
         assert batcher._running is True
-        assert batcher._batch_task is not None
+        # No background loop any more: requests drive their own inference
+        # instead of waiting for a timer to seal a window.
+        assert batcher._inflight == {}
 
         await batcher.stop()
         assert batcher._running is False
@@ -243,34 +261,60 @@ class TestRequestBatcher:
         await batcher.stop()
 
     @pytest.mark.asyncio
-    async def test_submit_timeout_raises_and_cleans_up_queue(self, mock_engine):
-        """A submit() timeout must raise and remove the request from the
-        queue, not leave a dead entry that would occupy a future batch slot."""
-        # max_batch_size high enough, and no start(), so nothing ever drains
-        # the queue: submit() has no way to resolve except the timeout.
-        batcher = RequestBatcher(engine=mock_engine, max_batch_size=100, max_wait_time_ms=50000.0)
+    async def test_submit_timeout_raises_without_leaking_state(self, mock_engine):
+        """
+        A submit() timeout must raise without leaking admission state.
 
-        with pytest.raises(asyncio.TimeoutError):
-            await batcher.submit("Never processed", max_tokens=50, timeout=0.05)
+        Under fan-out the timeout does *not* cancel the inference: other
+        waiters may still need it, and its result still populates the cache.
+        So the assertion is that the in-flight entry retires once the
+        inference finishes, not that it vanishes at timeout.
+        """
+        slow = _SlowBackend(delay=0.2)
+        batcher = RequestBatcher(engine=_EngineWith(slow), max_batch_size=4)
+        await batcher.start()
+        try:
+            with pytest.raises(asyncio.TimeoutError):
+                await batcher.submit("Slow one", max_tokens=50, timeout=0.05)
 
-        assert len(batcher._queue) == 0
-        assert batcher.get_metrics()["pending_requests"] == 0
+            # Still running: the shield kept it alive past the caller's timeout.
+            assert len(batcher._inflight) == 1
+
+            await batcher.stop()  # drains in-flight work
+            assert batcher._inflight == {}
+            assert batcher.get_metrics()["pending_requests"] == 0
+            # The result the caller gave up on is still cached.
+            assert slow.calls == 1
+        finally:
+            await batcher.stop()
 
     @pytest.mark.asyncio
-    async def test_submit_cancellation_cleans_up_queue(self, mock_engine):
-        """Cancelling the caller's task while awaiting submit() must remove
-        the request from the queue instead of leaking it."""
-        batcher = RequestBatcher(engine=mock_engine, max_batch_size=100, max_wait_time_ms=50000.0)
+    async def test_cancellation_does_not_kill_shared_inference(self, mock_engine):
+        """
+        One caller cancelling must not cancel an inference another caller is
+        waiting on -- that is the point of shielding the shared task.
+        """
+        slow = _SlowBackend(delay=0.15)
+        batcher = RequestBatcher(engine=_EngineWith(slow), max_batch_size=4)
+        await batcher.start()
+        try:
+            first = asyncio.create_task(batcher.submit("Shared", max_tokens=50))
+            await asyncio.sleep(0.01)
+            second = asyncio.create_task(batcher.submit("Shared", max_tokens=50))
+            await asyncio.sleep(0.01)
 
-        task = asyncio.create_task(batcher.submit("Never processed", max_tokens=50))
-        await asyncio.sleep(0.01)  # let it enqueue
-        assert len(batcher._queue) == 1
+            first.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await first
 
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
+            # The survivor still gets a result, from the same single inference.
+            result = await second
+            assert result["text"].startswith("Response to: Shared")
+            assert slow.calls == 1
+        finally:
+            await batcher.stop()
 
-        assert len(batcher._queue) == 0
+        assert batcher._inflight == {}
         assert batcher.get_metrics()["pending_requests"] == 0
 
     @pytest.mark.asyncio

--- a/tests/test_cache_log.py
+++ b/tests/test_cache_log.py
@@ -77,13 +77,15 @@ async def test_cache_hit_emits_debug_log(caplog, monkeypatch):
 
     await batcher.start()
     try:
-        async def _fake_run_batch_inference(prompts, max_tokens, temperature=0.7, top_p=0.9):
-            return [
-                {"text": f"Response to: {p[:30]}", "ttft": 0.0, "tpot": 0.001, "total_tokens": 10}
-                for p in prompts
-            ]
+        async def _fake_run_inference(prompt, max_tokens, temperature=0.7, top_p=0.9):
+            return {
+                "text": f"Response to: {prompt[:30]}",
+                "ttft": 0.0,
+                "tpot": 0.001,
+                "total_tokens": 10,
+            }
 
-        monkeypatch.setattr(batcher, "_run_batch_inference", _fake_run_batch_inference)
+        monkeypatch.setattr(batcher, "_run_inference", _fake_run_inference)
 
         with caplog.at_level(logging.DEBUG, logger="vgate.batcher"):
             await batcher.submit("Hello world", max_tokens=50, temperature=0.7, top_p=0.9)

--- a/tests/test_fanout.py
+++ b/tests/test_fanout.py
@@ -26,6 +26,7 @@ import time
 import pytest
 
 from vgate.batcher import RequestBatcher
+from vgate.cache import ResultCache
 
 
 class _RecordingBackend:
@@ -228,6 +229,84 @@ async def test_failed_inference_is_not_cached():
         await b.stop()
 
     assert len(backend.calls) == 2, "the retry must actually reach the backend"
+
+
+# --------------------------------------------------------------------------
+# Abandoned-request reclamation
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_abandoned_request_is_cancelled_before_admission():
+    """
+    A request nobody is waiting for any more, and that has not been admitted,
+    must not keep occupying an admission permit.
+    """
+    backend = _RecordingBackend(delay=0.15)
+    # One permit: the second request cannot start until the first finishes.
+    b = await _batcher(backend, max_batch_size=1)
+    try:
+        holder = asyncio.create_task(b.submit("holder", max_tokens=4))
+        await asyncio.sleep(0.02)  # let the holder take the only permit
+
+        # Queued behind the holder, then abandoned before it can start.
+        with pytest.raises(asyncio.TimeoutError):
+            await b.submit("queued", max_tokens=4, timeout=0.03)
+
+        await holder
+    finally:
+        await b.stop()
+
+    dispatched = [p for prompts, _ in backend.calls for p in prompts]
+    assert "queued" not in dispatched, "abandoned queued work should not run"
+    assert b._inflight == {}
+
+
+@pytest.mark.asyncio
+async def test_started_inference_survives_abandonment():
+    """
+    Once admitted, the work is committed: the thread-pool call cannot be
+    interrupted anyway, and its result still populates the cache. Cancelling
+    would pay for it and discard the answer.
+    """
+    backend = _RecordingBackend(delay=0.12)
+    b = await _batcher(backend, max_batch_size=4)
+    try:
+        with pytest.raises(asyncio.TimeoutError):
+            await b.submit("committed", max_tokens=4, timeout=0.03)
+
+        await b.stop()  # drain
+
+        # It ran to completion, and the result the caller gave up on is cached.
+        assert [p for prompts, _ in backend.calls for p in prompts] == ["committed"]
+        cached = await b.cache.get(ResultCache.make_key("committed", 0.7, 0.9, 4))
+        assert cached is not None
+    finally:
+        await b.stop()
+
+
+@pytest.mark.asyncio
+async def test_one_waiter_leaving_does_not_reclaim_shared_work():
+    """Reclamation must count waiters, not fire on the first departure."""
+    backend = _RecordingBackend(delay=0.15)
+    b = await _batcher(backend, max_batch_size=1)
+    try:
+        holder = asyncio.create_task(b.submit("holder", max_tokens=4))
+        await asyncio.sleep(0.02)
+
+        # Two waiters on the same queued request; one leaves, one stays.
+        stays = asyncio.create_task(b.submit("shared", max_tokens=4))
+        await asyncio.sleep(0.01)
+        with pytest.raises(asyncio.TimeoutError):
+            await b.submit("shared", max_tokens=4, timeout=0.02)
+
+        await holder
+        result = await stays
+        assert result["text"] == "out:shared"
+    finally:
+        await b.stop()
+
+    dispatched = [p for prompts, _ in backend.calls for p in prompts]
+    assert "shared" in dispatched, "work still had a waiter and must not be cancelled"
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_fanout.py
+++ b/tests/test_fanout.py
@@ -1,0 +1,259 @@
+# Copyright 2025 the V-Gate authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the dedup / admission / fan-out behavior of RequestBatcher.
+
+The property that matters for routing is that each request reaches the
+backend as its own call. The property that matters for cost is that
+identical concurrent requests reach it only once between them.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from vgate.batcher import RequestBatcher
+
+
+class _RecordingBackend:
+    """Records every generate() call so tests can assert on dispatch shape."""
+
+    supports_concurrent_calls = True
+
+    def __init__(self, delay: float = 0.0):
+        self.delay = delay
+        self.calls = []
+
+    def create_sampling_params(self, temperature, top_p, max_tokens):
+        return {"temperature": temperature, "top_p": top_p, "max_tokens": max_tokens}
+
+    def generate(self, prompts, sampling_params):
+        self.calls.append((list(prompts), dict(sampling_params)))
+        if self.delay:
+            time.sleep(self.delay)
+        return [
+            {"text": f"out:{p}", "token_ids": list(range(3)), "num_tokens": 3, "metrics": {}}
+            for p in prompts
+        ]
+
+    def shutdown(self):
+        pass
+
+
+class _Engine:
+    def __init__(self, backend):
+        self.backend = backend
+
+
+async def _batcher(backend, **kwargs) -> RequestBatcher:
+    b = RequestBatcher(engine=_Engine(backend), **kwargs)
+    await b.start()
+    return b
+
+
+# --------------------------------------------------------------------------
+# Fan-out
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_each_request_is_its_own_backend_call():
+    """
+    The routing-granularity property: distinct requests must not be merged
+    into one backend call, or a router could only place them as a group.
+    """
+    backend = _RecordingBackend()
+    b = await _batcher(backend, max_batch_size=8)
+    try:
+        await asyncio.gather(*(b.submit(f"p{i}", max_tokens=4) for i in range(5)))
+    finally:
+        await b.stop()
+
+    assert len(backend.calls) == 5, "expected one backend call per request"
+    for prompts, _ in backend.calls:
+        assert len(prompts) == 1, f"a call carried {len(prompts)} prompts"
+
+
+@pytest.mark.asyncio
+async def test_differing_sampling_params_stay_separate():
+    """Different params were the reason batches had to be split before; with
+    fan-out each request carries its own params by construction."""
+    backend = _RecordingBackend()
+    b = await _batcher(backend, max_batch_size=8)
+    try:
+        await asyncio.gather(
+            b.submit("same", max_tokens=4, temperature=0.1),
+            b.submit("same", max_tokens=4, temperature=0.9),
+        )
+    finally:
+        await b.stop()
+
+    assert len(backend.calls) == 2
+    temps = sorted(params["temperature"] for _, params in backend.calls)
+    assert temps == [0.1, 0.9], "params must not be shared across requests"
+
+
+# --------------------------------------------------------------------------
+# In-flight deduplication
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_identical_concurrent_requests_share_one_inference():
+    backend = _RecordingBackend(delay=0.05)
+    b = await _batcher(backend, max_batch_size=8)
+    try:
+        results = await asyncio.gather(
+            *(b.submit("duplicate", max_tokens=4) for _ in range(5))
+        )
+    finally:
+        await b.stop()
+
+    assert len(backend.calls) == 1, "5 identical requests should cost one inference"
+    assert all(r["text"] == "out:duplicate" for r in results)
+    assert b.get_metrics()["total_deduplicated"] == 4
+
+
+@pytest.mark.asyncio
+async def test_dedup_is_not_limited_to_a_time_window():
+    """
+    Coalescing follows the in-flight request, not a fixed window.
+
+    Under the old model two identical requests only merged if they landed in
+    the same batching window. Here the second one merges as long as the first
+    is still running, however late it arrives.
+    """
+    backend = _RecordingBackend(delay=0.2)
+    b = await _batcher(backend, max_batch_size=8)
+    try:
+        first = asyncio.create_task(b.submit("slow", max_tokens=4))
+        # Far longer than any old batching window would have been.
+        await asyncio.sleep(0.1)
+        second = asyncio.create_task(b.submit("slow", max_tokens=4))
+        await asyncio.gather(first, second)
+    finally:
+        await b.stop()
+
+    assert len(backend.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_sequential_identical_requests_hit_cache_not_dedup():
+    """Once the first completes, the second is a cache hit, not a coalesce."""
+    backend = _RecordingBackend()
+    b = await _batcher(backend, max_batch_size=8)
+    try:
+        await b.submit("once", max_tokens=4)
+        await b.submit("once", max_tokens=4)
+    finally:
+        await b.stop()
+
+    assert len(backend.calls) == 1
+    stats = b.get_metrics()
+    assert stats["total_deduplicated"] == 0
+    assert stats["cache"]["hits"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_failed_inference_propagates_to_all_waiters():
+    """A shared failure must reach every coalesced caller, not just the leader."""
+
+    class _FailingBackend(_RecordingBackend):
+        def generate(self, prompts, sampling_params):
+            time.sleep(0.03)
+            raise RuntimeError("backend exploded")
+
+    backend = _FailingBackend()
+    b = await _batcher(backend, max_batch_size=8)
+    try:
+        results = await asyncio.gather(
+            *(b.submit("doomed", max_tokens=4) for _ in range(3)),
+            return_exceptions=True,
+        )
+    finally:
+        await b.stop()
+
+    assert len(results) == 3
+    assert all(isinstance(r, RuntimeError) for r in results), results
+
+
+@pytest.mark.asyncio
+async def test_inflight_map_is_empty_after_completion():
+    backend = _RecordingBackend()
+    b = await _batcher(backend, max_batch_size=4)
+    try:
+        await asyncio.gather(*(b.submit(f"x{i}", max_tokens=4) for i in range(4)))
+        assert b._inflight == {}
+    finally:
+        await b.stop()
+
+
+@pytest.mark.asyncio
+async def test_failed_inference_is_not_cached():
+    """A failure must not poison the cache for later retries."""
+
+    state = {"fail": True}
+
+    class _FlakyBackend(_RecordingBackend):
+        def generate(self, prompts, sampling_params):
+            self.calls.append((list(prompts), dict(sampling_params)))
+            if state["fail"]:
+                raise RuntimeError("transient")
+            return [
+                {"text": f"out:{p}", "token_ids": [1], "num_tokens": 1, "metrics": {}}
+                for p in prompts
+            ]
+
+    backend = _FlakyBackend()
+    b = await _batcher(backend, max_batch_size=4)
+    try:
+        with pytest.raises(RuntimeError):
+            await b.submit("retryable", max_tokens=4)
+
+        state["fail"] = False
+        result = await b.submit("retryable", max_tokens=4)
+        assert result["text"] == "out:retryable"
+    finally:
+        await b.stop()
+
+    assert len(backend.calls) == 2, "the retry must actually reach the backend"
+
+
+# --------------------------------------------------------------------------
+# Admission
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_deduplicated_waiters_do_not_consume_admission_permits():
+    """
+    Followers wait on someone else's inference, so they must not hold a
+    permit -- otherwise N duplicates of one prompt would exhaust admission
+    while only one inference is actually running.
+    """
+    backend = _RecordingBackend(delay=0.1)
+    b = await _batcher(backend, max_batch_size=2)
+    try:
+        dupes = [asyncio.create_task(b.submit("shared", max_tokens=4)) for _ in range(5)]
+        await asyncio.sleep(0.03)
+
+        # One permit is held by the leader; a different prompt must still be
+        # admitted rather than queueing behind the four followers.
+        other = await asyncio.wait_for(b.submit("different", max_tokens=4), timeout=1.0)
+        assert other["text"] == "out:different"
+
+        await asyncio.gather(*dupes)
+    finally:
+        await b.stop()
+
+    assert len(backend.calls) == 2

--- a/tests/test_worker_split.py
+++ b/tests/test_worker_split.py
@@ -337,8 +337,14 @@ def test_batcher_does_not_serialize_concurrent_safe_backends():
 
 
 @pytest.mark.asyncio
-async def test_concurrent_batches_overlap_with_remote_backend():
-    """Two batches should be in flight at once when the backend allows it."""
+async def test_concurrent_inferences_overlap_with_remote_backend():
+    """
+    Several inferences should overlap when the backend allows concurrency.
+
+    max_batch_size is the admission limit now, so it has to be above 1 for
+    anything to overlap -- under the old batching model it sized the window
+    instead, and separate windows could overlap regardless of its value.
+    """
     concurrent = 0
     peak = 0
 
@@ -357,11 +363,78 @@ async def test_concurrent_batches_overlap_with_remote_backend():
             concurrent -= 1
             return [{"text": p, "token_ids": [], "num_tokens": 1, "metrics": {}} for p in prompts]
 
-    batcher = RequestBatcher(engine=_Engine(_SlowConcurrentBackend()), max_batch_size=1)
+    batcher = RequestBatcher(engine=_Engine(_SlowConcurrentBackend()), max_batch_size=4)
     await batcher.start()
     try:
         await asyncio.gather(*(batcher.submit(f"p{i}", max_tokens=4) for i in range(4)))
     finally:
         await batcher.stop()
 
-    assert peak > 1, f"expected overlapping batches, peak concurrency was {peak}"
+    assert peak > 1, f"expected overlapping inferences, peak concurrency was {peak}"
+
+
+@pytest.mark.asyncio
+async def test_admission_limit_caps_concurrency():
+    """max_batch_size must actually bound concurrent backend calls."""
+    concurrent = 0
+    peak = 0
+
+    class _CountingBackend:
+        supports_concurrent_calls = True
+
+        def create_sampling_params(self, temperature, top_p, max_tokens):
+            return {"temperature": temperature, "top_p": top_p, "max_tokens": max_tokens}
+
+        def generate(self, prompts, sampling_params):
+            nonlocal concurrent, peak
+            concurrent += 1
+            peak = max(peak, concurrent)
+            import time as _t
+            _t.sleep(0.03)
+            concurrent -= 1
+            return [{"text": p, "token_ids": [], "num_tokens": 1, "metrics": {}} for p in prompts]
+
+    batcher = RequestBatcher(engine=_Engine(_CountingBackend()), max_batch_size=2)
+    await batcher.start()
+    try:
+        await asyncio.gather(*(batcher.submit(f"q{i}", max_tokens=4) for i in range(8)))
+    finally:
+        await batcher.stop()
+
+    assert peak <= 2, f"admission limit of 2 was exceeded: peak was {peak}"
+
+
+@pytest.mark.asyncio
+async def test_local_backend_is_serialized_to_one_inference():
+    """
+    A backend that does not declare concurrency safety must never see two
+    calls at once, regardless of max_batch_size.
+
+    Under the old model a separate lock enforced this. With fan-out the
+    admission limit carries it, so this asserts the constraint survived the
+    rewrite rather than the mechanism that used to provide it.
+    """
+    concurrent = 0
+    peak = 0
+
+    class _UnsafeBackend:  # no supports_concurrent_calls -> serialized
+        def create_sampling_params(self, temperature, top_p, max_tokens):
+            return {"temperature": temperature, "top_p": top_p, "max_tokens": max_tokens}
+
+        def generate(self, prompts, sampling_params):
+            nonlocal concurrent, peak
+            concurrent += 1
+            peak = max(peak, concurrent)
+            import time as _t
+            _t.sleep(0.02)
+            concurrent -= 1
+            return [{"text": p, "token_ids": [], "num_tokens": 1, "metrics": {}} for p in prompts]
+
+    batcher = RequestBatcher(engine=_Engine(_UnsafeBackend()), max_batch_size=8)
+    await batcher.start()
+    try:
+        await asyncio.gather(*(batcher.submit(f"r{i}", max_tokens=4) for i in range(6)))
+    finally:
+        await batcher.stop()
+
+    assert peak == 1, f"unsafe backend saw {peak} concurrent calls"

--- a/tests/test_worker_split.py
+++ b/tests/test_worker_split.py
@@ -320,9 +320,19 @@ class _Engine:
         self.is_remote = is_remote
 
 
-def test_batcher_serializes_local_backends():
-    batcher = RequestBatcher(engine=_Engine(DryRunBackend()))
+def test_batcher_serializes_backends_that_do_not_declare_concurrency():
+    """Serialization is opt-out, so an undeclared backend stays protected."""
+
+    class _Undeclared:
+        def create_sampling_params(self, temperature, top_p, max_tokens):
+            return {}
+
+        def generate(self, prompts, sampling_params):
+            return []
+
+    batcher = RequestBatcher(engine=_Engine(_Undeclared()))
     assert batcher._serialize_inference is True
+    assert batcher.max_concurrent_inferences == 1
 
 
 def test_batcher_does_not_serialize_concurrent_safe_backends():
@@ -330,10 +340,21 @@ def test_batcher_does_not_serialize_concurrent_safe_backends():
     # adding workers would not increase throughput.
     backend = RemoteBackend(WorkerConfig(endpoints=["http://w:8001"]))
     try:
-        batcher = RequestBatcher(engine=_Engine(backend))
+        batcher = RequestBatcher(engine=_Engine(backend), max_batch_size=8)
         assert batcher._serialize_inference is False
+        assert batcher.max_concurrent_inferences == 8
     finally:
         backend.shutdown()
+
+
+def test_dry_run_backend_is_concurrency_safe():
+    """
+    DryRunBackend is stateless, so serializing it would make dry-run
+    benchmarks measure an artificial bottleneck the real backends lack.
+    """
+    batcher = RequestBatcher(engine=_Engine(DryRunBackend()), max_batch_size=4)
+    assert batcher._serialize_inference is False
+    assert batcher.max_concurrent_inferences == 4
 
 
 @pytest.mark.asyncio

--- a/vgate/backends/base.py
+++ b/vgate/backends/base.py
@@ -64,6 +64,11 @@ class InferenceBackend(Protocol):
 class DryRunBackend:
     """Mock backend that returns placeholder responses without GPU."""
 
+    # Stateless: each call only reads its arguments, so concurrent calls are
+    # safe. Declaring it keeps dry-run benchmarks from measuring an artificial
+    # serialization that the real backends do not have.
+    supports_concurrent_calls = True
+
     def load_model(self, model_config: ModelConfig) -> None:
         pass
 

--- a/vgate/backends/sglang_backend.py
+++ b/vgate/backends/sglang_backend.py
@@ -21,6 +21,12 @@ from vgate.config import ModelConfig
 class SGLangBackend:
     """Inference backend using SGLang."""
 
+    # Deliberately not declaring supports_concurrent_calls. generate() calls
+    # the synchronous sgl.Engine directly, and this adapter has never been
+    # exercised against a live engine, so its concurrency behavior is
+    # unverified. Calls stay serialized until that is measured rather than
+    # assumed -- see ROADMAP Phase 2 task 8.
+
     def __init__(self):
         self.engine = None
 

--- a/vgate/backends/vllm_backend.py
+++ b/vgate/backends/vllm_backend.py
@@ -47,6 +47,13 @@ class VLLMBackend:
     redefinition in ROADMAP.md Phase 2 task 9.
     """
 
+    # AsyncLLMEngine exists to serve concurrent requests: generate() bridges
+    # into its loop and submits every prompt with asyncio.gather, and the
+    # engine interleaves them via continuous batching. Serializing calls to
+    # this backend would switch that off and leave the GPU decoding one
+    # sequence at a time.
+    supports_concurrent_calls = True
+
     def __init__(self):
         self.engine = None
         self._loop: asyncio.AbstractEventLoop | None = None

--- a/vgate/batcher.py
+++ b/vgate/batcher.py
@@ -13,46 +13,49 @@
 # limitations under the License.
 
 import asyncio
+import functools
 import time
-from contextlib import nullcontext
-from typing import Any, Dict, List, Optional
-from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
 
 from vgate.cache import ResultCache
-from vgate.config import get_config, CacheConfig as ConfigCacheConfig
+from vgate.config import get_config
 from vgate.logging_config import get_logger
 from vgate.tracing import get_tracer, get_current_trace_id
 from vgate.metrics import (
     BATCH_SIZE, BATCH_PROCESSING_TIME, BATCH_QUEUE_TIME,
     PENDING_REQUESTS, TOTAL_BATCHES, TTFT, TPOT,
     TOKENS_GENERATED, INFERENCE_ERRORS, UNIQUE_PROMPTS_PER_BATCH,
-    DEDUPLICATED_REQUESTS, DEDUP_RATIO
+    DEDUPLICATED_REQUESTS, DEDUP_RATIO, INFLIGHT_INFERENCES
 )
 
 logger = get_logger("vgate.batcher")
 tracer = get_tracer("vgate.batcher")
 
 
-@dataclass
-class BatchRequest:
-    """A single request waiting to be batched."""
-    prompt: str
-    max_tokens: int
-    temperature: float = 0.7
-    top_p: float = 0.9
-    cache_key: str = ""
-    future: asyncio.Future = field(default_factory=lambda: asyncio.get_event_loop().create_future())
-    created_at: float = field(default_factory=time.monotonic)  # monotonic: used only for queue-time deltas
-
-
 class RequestBatcher:
     """
-    Dynamic request batcher that aggregates concurrent requests
-    and processes them in batches for improved GPU utilization.
+    Admission control, in-flight deduplication, and fan-out to the backend.
 
-    Batching triggers when either condition is met:
-    - Batch size reaches max_batch_size
-    - Wait time exceeds max_wait_time_ms
+    Despite the name, this no longer builds batches. It used to collect
+    requests into a window and hand the whole window to one backend call,
+    which made sense when the backend was an in-process engine that benefited
+    from receiving several prompts at once. Two things made that wrong:
+
+    - vLLM and SGLang do continuous batching internally, and do it better --
+      they can admit a new request into a batch that is already decoding,
+      which a sealed Python-side window cannot.
+    - With remote workers, a sealed batch is routed as a unit, so every
+      request in it lands on the same worker regardless of load. Load-aware
+      routing needs a decision per request, not per window.
+
+    So the three things worth keeping were separated from batch construction:
+
+    - **Deduplication**: concurrent identical requests share one inference.
+      This is now stronger than before, because coalescing is not limited to
+      requests that happened to land in the same window.
+    - **Admission control**: `max_batch_size` bounds concurrent inferences.
+    - **Fan-out**: each admitted request calls the backend on its own, so a
+      router sees one decision per request.
     """
 
     def __init__(
@@ -62,31 +65,42 @@ class RequestBatcher:
         max_wait_time_ms: Optional[float] = None,
     ):
         """
-        Initialize the request batcher.
-
         Args:
             engine: The VGateEngine instance.
-            max_batch_size: Max requests per batch. Uses config default if None.
-            max_wait_time_ms: Max wait time before processing. Uses config default if None.
+            max_batch_size: Maximum concurrent inferences. Retains its
+                configuration key, but now bounds concurrency rather than
+                window size -- there is no window to size.
+            max_wait_time_ms: Accepted and ignored. Kept so existing configs
+                and callers keep working; a deprecation warning is logged
+                when it is set to a non-default value.
         """
         config = get_config()
         self.engine = engine
-        self.max_batch_size = max_batch_size if max_batch_size is not None else config.batch.max_batch_size
-        self.max_wait_time_ms = max_wait_time_ms if max_wait_time_ms is not None else config.batch.max_wait_time_ms
+        self.max_batch_size = (
+            max_batch_size if max_batch_size is not None else config.batch.max_batch_size
+        )
+        self.max_wait_time_ms = (
+            max_wait_time_ms if max_wait_time_ms is not None else config.batch.max_wait_time_ms
+        )
         self.cache = ResultCache()
 
-        self._queue: List[BatchRequest] = []
-        self._lock = asyncio.Lock()
-        self._inference_lock = asyncio.Lock()  # Prevent concurrent vLLM calls
-        # In-process engines are not safe to call concurrently, so batches are
-        # serialized through _inference_lock. A backend that forwards over the
-        # network has no such constraint, and holding the lock there would
-        # serialize every worker call — making additional workers useless.
-        # Backends opt out by declaring supports_concurrent_calls; the default
-        # stays locked, so local backends are unaffected.
+        # In-process engines are not safe to call concurrently. Under the old
+        # batching model a separate lock enforced that; with fan-out, every
+        # request calls the backend on its own, so the constraint is expressed
+        # as the admission limit itself -- one mechanism instead of two.
+        # Backends opt into concurrency via supports_concurrent_calls; the
+        # default is serial, so local backends stay protected.
         backend = getattr(engine, "backend", None)
         self._serialize_inference = not getattr(backend, "supports_concurrent_calls", False)
-        self._batch_task: asyncio.Task = None
+        self.max_concurrent_inferences = 1 if self._serialize_inference else self.max_batch_size
+
+        # Bounds concurrent backend calls. Holders are the requests actually
+        # running inference; deduplicated followers do not consume a permit.
+        self._semaphore = asyncio.Semaphore(self.max_concurrent_inferences)
+        # cache_key -> the task computing it. Any later request for the same
+        # key attaches to this task instead of starting a second inference.
+        self._inflight: Dict[str, asyncio.Task] = {}
+        self._lock = asyncio.Lock()
         self._running = False
 
         # Metrics
@@ -99,36 +113,43 @@ class RequestBatcher:
         self.total_ttft = 0.0
         self.total_tpot = 0.0
         self.total_inference_samples = 0
+        self._waiting = 0
 
     async def start(self):
-        """Start the background batching task."""
+        """
+        Mark the batcher running.
+
+        There is no background loop any more: a request drives its own
+        inference instead of waiting for a timer to seal a window.
+        """
         if self._running:
             return
         self._running = True
-        self._batch_task = asyncio.create_task(self._batch_loop())
         logger.info(
             "Batcher started",
             extra={"extra_data": {
-                "max_batch_size": self.max_batch_size,
-                "max_wait_time_ms": self.max_wait_time_ms
+                "max_concurrent_inferences": self.max_concurrent_inferences,
+                "serialized_backend": self._serialize_inference,
+                "mode": "dedup+admission+fanout",
+                # Surfaced rather than warned about: the key is still accepted
+                # so existing configs load, but it no longer does anything.
+                "max_wait_time_ms_ignored": self.max_wait_time_ms,
             }}
         )
 
     async def stop(self):
-        """Stop the batching task and process remaining requests."""
+        """
+        Stop accepting work and let in-flight inferences finish.
+
+        Cancelling them would leave their waiters with unresolved futures, and
+        their results are already paid for -- draining also populates the
+        cache, so the work is not wasted.
+        """
         self._running = False
-        if self._batch_task:
-            self._batch_task.cancel()
-            try:
-                await self._batch_task
-            except asyncio.CancelledError:
-                pass
-        # Process any remaining requests. _process_batch only drains up to
-        # max_batch_size per call, so loop until the queue is fully empty —
-        # otherwise a queue longer than max_batch_size would strand requests
-        # with unresolved futures on shutdown.
-        while self._queue:
-            await self._process_batch()
+        async with self._lock:
+            pending = list(self._inflight.values())
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
         logger.info("Batcher stopped")
 
     async def submit(
@@ -140,9 +161,10 @@ class RequestBatcher:
         timeout: Optional[float] = None,
     ) -> Dict[str, Any]:
         """
-        Submit a request for batched processing.
-        Returns the result when the batch is processed.
-        Checks cache first and returns cached result if available.
+        Submit a request, returning its result.
+
+        Checks the cache, coalesces onto an identical in-flight request if one
+        exists, and otherwise runs the inference under the concurrency limit.
 
         Args:
             prompt: The input prompt.
@@ -150,15 +172,15 @@ class RequestBatcher:
             temperature: Sampling temperature. Uses config default if None.
             top_p: Top-p sampling. Uses config default if None.
             timeout: Max seconds to wait for a result. Raises
-                asyncio.TimeoutError and removes the request from the queue
-                if it hasn't been picked up by a batch yet. No timeout if None.
+                asyncio.TimeoutError when it elapses. The underlying
+                inference is not cancelled -- other waiters may still need
+                it, and its result still populates the cache.
 
         Raises:
             asyncio.TimeoutError: if `timeout` elapses before a result is ready.
             asyncio.CancelledError: if the calling task is cancelled while waiting.
         """
         with tracer.start_as_current_span("batcher.submit") as span:
-            # Apply defaults from config
             config = get_config()
             if max_tokens is None:
                 max_tokens = config.inference.max_tokens
@@ -171,7 +193,6 @@ class RequestBatcher:
 
             cache_key = ResultCache.make_key(prompt, temperature, top_p, max_tokens)
 
-            # Check cache first
             cached = await self.cache.get(cache_key)
             if cached:
                 span.set_attribute("cache_hit", True)
@@ -182,280 +203,188 @@ class RequestBatcher:
                 return cached
 
             span.set_attribute("cache_hit", False)
-
-            request = BatchRequest(
-                prompt=prompt,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
-                cache_key=cache_key,
-                future=asyncio.get_event_loop().create_future(),
-                created_at=time.monotonic(),
-            )
+            self.total_requests += 1
 
             async with self._lock:
-                self._queue.append(request)
-                self.total_requests += 1
-                queue_size = len(self._queue)
-                PENDING_REQUESTS.set(queue_size)
+                task = self._inflight.get(cache_key)
+                coalesced = task is not None
+                if task is None:
+                    task = asyncio.create_task(
+                        self._execute(cache_key, prompt, temperature, top_p, max_tokens)
+                    )
+                    self._inflight[cache_key] = task
+                    task.add_done_callback(
+                        functools.partial(self._retire, cache_key)
+                    )
 
-            # If batch is full, signal immediate processing
-            if queue_size >= self.max_batch_size:
-                asyncio.create_task(self._process_batch())
-
-            # Wait for result
-            try:
-                if timeout is not None:
-                    result = await asyncio.wait_for(request.future, timeout=timeout)
-                else:
-                    result = await request.future
-                return result
-            finally:
-                # Best-effort cleanup: if this request timed out, was
-                # cancelled, or errored before a batch picked it up, remove
-                # it from the queue instead of leaving a dead entry that
-                # would still occupy a batch slot later. No-op if it was
-                # already dequeued for processing.
-                async with self._lock:
-                    before = len(self._queue)
-                    self._queue = [r for r in self._queue if r is not request]
-                    if len(self._queue) != before:
-                        PENDING_REQUESTS.set(len(self._queue))
-
-    async def _batch_loop(self):
-        """Background loop that triggers batch processing on timeout."""
-        while self._running:
-            await asyncio.sleep(self.max_wait_time_ms / 1000.0)
-
-            if self._queue:
-                await self._process_batch()
-
-    async def _process_batch(self):
-        """Process up to max_batch_size pending requests as a batch, with deduplication."""
-        # Serialize batches only when the backend requires it (see __init__).
-        # nullcontext supports async use on Python 3.10+.
-        inference_guard = self._inference_lock if self._serialize_inference else nullcontext()
-        async with inference_guard:
-            async with self._lock:
-                if not self._queue:
-                    return
-
-                # Take at most max_batch_size requests; leave any excess
-                # queued for the next drain instead of unboundedly growing
-                # the batch (submit() re-triggers processing whenever the
-                # queue is at/above max_batch_size, so leftovers get picked
-                # up promptly rather than waiting for the next timeout tick).
-                batch = self._queue[:self.max_batch_size]
-                self._queue = self._queue[self.max_batch_size:]
-                PENDING_REQUESTS.set(len(self._queue))
-
-            if not batch:
-                return
-
-            batch_size = len(batch)
-            self.total_batches += 1
-            self.total_batch_size += batch_size
-
-            with tracer.start_as_current_span("batcher.process_batch") as span:
-                # Record batch metrics
-                TOTAL_BATCHES.inc()
-                BATCH_SIZE.observe(batch_size)
-
-                span.set_attribute("batch_id", self.total_batches)
-                span.set_attribute("batch_size", batch_size)
-
-                # Calculate queue wait times (monotonic: immune to wall-clock adjustments)
-                current_time = time.monotonic()
-                for req in batch:
-                    queue_time = current_time - req.created_at
-                    BATCH_QUEUE_TIME.observe(queue_time)
-                    self.total_queue_time += queue_time
-                    self.total_queue_samples += 1
-
-                logger.info(
-                    "Processing batch",
-                    extra={"extra_data": {
-                        "batch_id": self.total_batches,
-                        "batch_size": batch_size
-                    }}
+            span.set_attribute("deduplicated", coalesced)
+            if coalesced:
+                self.total_deduplicated += 1
+                DEDUPLICATED_REQUESTS.inc()
+                DEDUP_RATIO.set(
+                    self.total_deduplicated / self.total_requests
+                    if self.total_requests else 0
+                )
+                logger.debug(
+                    "Coalesced onto in-flight request",
+                    extra={"extra_data": {"cache_key": cache_key[:8]}}
                 )
 
-                try:
-                    # Group requests by cache_key for deduplication (same key
-                    # implies identical prompt + temperature + top_p + max_tokens).
-                    unique_prompts: Dict[str, List[BatchRequest]] = {}
-                    for req in batch:
-                        if req.cache_key not in unique_prompts:
-                            unique_prompts[req.cache_key] = []
-                        unique_prompts[req.cache_key].append(req)
+            # shield: one waiter timing out or disconnecting must not cancel
+            # an inference that other waiters are still expecting.
+            if timeout is not None:
+                return await asyncio.wait_for(asyncio.shield(task), timeout=timeout)
+            return await asyncio.shield(task)
 
-                    dedup_count = batch_size - len(unique_prompts)
-                    span.set_attribute("unique_prompts", len(unique_prompts))
-                    span.set_attribute("deduplicated", dedup_count)
+    def _retire(self, cache_key: str, task: asyncio.Task) -> None:
+        """Drop a finished task from the in-flight map. Runs as a done-callback."""
+        current = self._inflight.get(cache_key)
+        if current is task:
+            # Mutating a dict from a done-callback is safe: callbacks run on
+            # the event loop thread, same as everything that reads it.
+            self._inflight.pop(cache_key, None)
 
-                    if dedup_count > 0:
-                        self.total_deduplicated += dedup_count
-                        DEDUPLICATED_REQUESTS.inc(dedup_count)
-                        DEDUP_RATIO.set(dedup_count / batch_size)
-                        logger.info(
-                            "Deduplicated requests",
-                            extra={"extra_data": {
-                                "deduplicated": dedup_count,
-                                "unique_prompts": len(unique_prompts)
-                            }}
-                        )
-                    else:
-                        DEDUP_RATIO.set(0)
-
-                    UNIQUE_PROMPTS_PER_BATCH.observe(len(unique_prompts))
-
-                    # A single backend.generate() call applies one shared
-                    # SamplingParams to every prompt it's given, so requests
-                    # with different (temperature, top_p, max_tokens) cannot
-                    # share a call — group deduplicated requests by their
-                    # params and dispatch one call per group.
-                    params_groups: Dict[tuple, List[str]] = {}
-                    for cache_key, reqs in unique_prompts.items():
-                        params_key = (reqs[0].temperature, reqs[0].top_p, reqs[0].max_tokens)
-                        params_groups.setdefault(params_key, []).append(cache_key)
-
-                    total_tokens = 0
-                    for (temperature, top_p, max_tokens), cache_keys in params_groups.items():
-                        prompts_to_infer = [unique_prompts[k][0].prompt for k in cache_keys]
-
-                        group_start = time.perf_counter()
-                        results = await self._run_batch_inference(
-                            prompts_to_infer, max_tokens, temperature, top_p
-                        )
-                        group_duration = time.perf_counter() - group_start
-
-                        # Exemplar for metric-trace correlation
-                        trace_id = get_current_trace_id()
-                        exemplar = {"trace_id": trace_id} if trace_id else None
-                        BATCH_PROCESSING_TIME.observe(group_duration, exemplar=exemplar)
-
-                        for cache_key, result in zip(cache_keys, results):
-                            if result.get("ttft", 0) > 0:
-                                TTFT.observe(result["ttft"])
-                                self.total_ttft += result["ttft"]
-                            if result.get("tpot", 0) > 0:
-                                TPOT.observe(result["tpot"])
-                                self.total_tpot += result["tpot"]
-                                self.total_inference_samples += 1
-                            tokens = result.get("total_tokens", 0)
-                            TOKENS_GENERATED.inc(tokens)
-                            total_tokens += tokens
-
-                            # Store in cache and distribute to all requests
-                            # sharing this cache_key.
-                            await self.cache.put(cache_key, result)
-                            for req in unique_prompts[cache_key]:
-                                if not req.future.done():
-                                    req.future.set_result(result)
-
-                    logger.info(
-                        "Batch inference completed",
-                        extra={"extra_data": {
-                            "batch_id": self.total_batches,
-                            "prompts": len(unique_prompts),
-                            "param_groups": len(params_groups),
-                            "tokens": total_tokens
-                        }}
-                    )
-
-                except Exception as e:
-                    span.set_attribute("error", True)
-                    # On error, fail all requests in batch
-                    INFERENCE_ERRORS.labels(error_type=type(e).__name__).inc()
-                    logger.error(
-                        "Batch processing error",
-                        extra={"extra_data": {
-                            "batch_id": self.total_batches,
-                            "error": str(e),
-                            "error_type": type(e).__name__
-                        }}
-                    )
-                    for req in batch:
-                        if not req.future.done():
-                            req.future.set_exception(e)
-
-    async def _run_batch_inference(
+    async def _execute(
         self,
-        prompts: List[str],
+        cache_key: str,
+        prompt: str,
+        temperature: float,
+        top_p: float,
+        max_tokens: int,
+    ) -> Dict[str, Any]:
+        """Wait for an admission permit, run one inference, and cache it."""
+        queued_at = time.monotonic()
+        self._waiting += 1
+        PENDING_REQUESTS.set(self._waiting)
+        # Tracks whether this request is still counted as waiting, so a
+        # cancellation while blocked on the semaphore does not leak the count.
+        counted_as_waiting = True
+        try:
+            async with self._semaphore:
+                self._waiting -= 1
+                counted_as_waiting = False
+                PENDING_REQUESTS.set(self._waiting)
+
+                queue_time = time.monotonic() - queued_at
+                BATCH_QUEUE_TIME.observe(queue_time)
+                self.total_queue_time += queue_time
+                self.total_queue_samples += 1
+
+                INFLIGHT_INFERENCES.inc()
+                try:
+                    result = await self._run_inference(
+                        prompt, max_tokens, temperature, top_p
+                    )
+                finally:
+                    INFLIGHT_INFERENCES.dec()
+        finally:
+            if counted_as_waiting:
+                self._waiting -= 1
+                PENDING_REQUESTS.set(self._waiting)
+
+        await self.cache.put(cache_key, result)
+        return result
+
+    async def _run_inference(
+        self,
+        prompt: str,
         max_tokens: int,
         temperature: float = 0.7,
         top_p: float = 0.9,
-    ) -> List[Dict[str, Any]]:
+    ) -> Dict[str, Any]:
         """
-        Run batched inference through the engine.
-        This runs in a thread pool to avoid blocking the event loop.
-        OTel context is captured and re-attached in the thread.
+        Run one inference off the event loop.
+
+        backend.generate() is synchronous per the InferenceBackend protocol,
+        so it goes to a thread. OTel context is captured and re-attached
+        across that boundary.
         """
         from opentelemetry import context as otel_context
 
         loop = asyncio.get_event_loop()
-
-        # Capture OTel context before crossing thread boundary
         ctx = otel_context.get_current()
 
         def _inference_with_context():
-            # Re-attach OTel context in the thread pool thread
             token = otel_context.attach(ctx)
             try:
                 with tracer.start_as_current_span("batcher.inference") as span:
-                    span.set_attribute("num_prompts", len(prompts))
-                    results = self._sync_batch_inference(
-                        prompts, max_tokens, temperature, top_p
-                    )
-                    total_tokens = sum(r.get("total_tokens", 0) for r in results)
-                    span.set_attribute("total_tokens_generated", total_tokens)
-                    return results
+                    span.set_attribute("num_prompts", 1)
+                    result = self._sync_inference(prompt, max_tokens, temperature, top_p)
+                    span.set_attribute("total_tokens_generated", result.get("total_tokens", 0))
+                    return result
             finally:
                 otel_context.detach(token)
 
-        results = await loop.run_in_executor(None, _inference_with_context)
-        return results
+        started = time.perf_counter()
+        try:
+            result = await loop.run_in_executor(None, _inference_with_context)
+        except Exception as e:
+            INFERENCE_ERRORS.labels(error_type=type(e).__name__).inc()
+            logger.error(
+                "Inference error",
+                extra={"extra_data": {"error": str(e), "error_type": type(e).__name__}}
+            )
+            raise
+        duration = time.perf_counter() - started
 
-    def _sync_batch_inference(
+        trace_id = get_current_trace_id()
+        exemplar = {"trace_id": trace_id} if trace_id else None
+        BATCH_PROCESSING_TIME.observe(duration, exemplar=exemplar)
+
+        # One backend call per request now. These two keep their meaning --
+        # "prompts handed to one backend call" -- the distribution is simply
+        # degenerate while fan-out is one prompt per call.
+        self.total_batches += 1
+        self.total_batch_size += 1
+        TOTAL_BATCHES.inc()
+        BATCH_SIZE.observe(1)
+        UNIQUE_PROMPTS_PER_BATCH.observe(1)
+
+        if result.get("ttft", 0) > 0:
+            TTFT.observe(result["ttft"])
+            self.total_ttft += result["ttft"]
+        if result.get("tpot", 0) > 0:
+            TPOT.observe(result["tpot"])
+            self.total_tpot += result["tpot"]
+            self.total_inference_samples += 1
+        TOKENS_GENERATED.inc(result.get("total_tokens", 0))
+
+        return result
+
+    def _sync_inference(
         self,
-        prompts: List[str],
+        prompt: str,
         max_tokens: int,
         temperature: float = 0.7,
         top_p: float = 0.9,
-    ) -> List[Dict[str, Any]]:
-        """Synchronous batch inference - runs in thread pool."""
+    ) -> Dict[str, Any]:
+        """Synchronous single-prompt inference - runs in the thread pool."""
         backend = self.engine.backend
         sampling_params = backend.create_sampling_params(
             temperature=temperature, top_p=top_p, max_tokens=max_tokens
         )
 
         start_time = time.perf_counter()
-        backend_results = backend.generate(prompts, sampling_params)
-        end_time = time.perf_counter()
+        backend_results = backend.generate([prompt], sampling_params)
+        total_time = time.perf_counter() - start_time
 
-        total_time = end_time - start_time
+        br = backend_results[0]
+        num_tokens = br["num_tokens"]
+        metrics = br.get("metrics", {})
 
-        results = []
-        for br in backend_results:
-            num_tokens = br["num_tokens"]
-            metrics = br.get("metrics", {})
+        ttft = metrics.get("ttft", 0.0)
+        gen_time = metrics.get("gen_time", total_time)
+        tpot = (gen_time / num_tokens) if num_tokens > 0 else 0
 
-            ttft = metrics.get("ttft", 0.0)
-            gen_time = metrics.get("gen_time", total_time / len(prompts))
-
-            tpot = (gen_time / num_tokens) if num_tokens > 0 else 0
-
-            results.append({
-                "text": br["text"],
-                "ttft": ttft,
-                "tpot": tpot,
-                "total_tokens": num_tokens,
-            })
-
-        return results
+        return {
+            "text": br["text"],
+            "ttft": ttft,
+            "tpot": tpot,
+            "total_tokens": num_tokens,
+        }
 
     def get_metrics(self) -> Dict[str, Any]:
-        """Return batching metrics including cache stats."""
+        """Return admission/dedup metrics including cache stats."""
         avg_batch_size = (self.total_batch_size / self.total_batches) if self.total_batches > 0 else 0
         avg_queue_time = (
             self.total_queue_time / self.total_queue_samples if self.total_queue_samples > 0 else 0
@@ -470,7 +399,8 @@ class RequestBatcher:
             "total_requests": self.total_requests,
             "total_batches": self.total_batches,
             "average_batch_size": round(avg_batch_size, 2),
-            "pending_requests": len(self._queue),
+            "pending_requests": self._waiting,
+            "inflight_inferences": len(self._inflight),
             "total_deduplicated": self.total_deduplicated,
             "avg_queue_time_s": round(avg_queue_time, 4),
             "avg_ttft_s": round(avg_ttft, 4),

--- a/vgate/batcher.py
+++ b/vgate/batcher.py
@@ -15,6 +15,7 @@
 import asyncio
 import functools
 import time
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 from vgate.cache import ResultCache
@@ -25,11 +26,33 @@ from vgate.metrics import (
     BATCH_SIZE, BATCH_PROCESSING_TIME, BATCH_QUEUE_TIME,
     PENDING_REQUESTS, TOTAL_BATCHES, TTFT, TPOT,
     TOKENS_GENERATED, INFERENCE_ERRORS, UNIQUE_PROMPTS_PER_BATCH,
-    DEDUPLICATED_REQUESTS, DEDUP_RATIO, INFLIGHT_INFERENCES
+    DEDUPLICATED_REQUESTS, DEDUP_RATIO, INFLIGHT_INFERENCES,
+    ABANDONED_INFERENCES
 )
 
 logger = get_logger("vgate.batcher")
 tracer = get_tracer("vgate.batcher")
+
+
+@dataclass
+class _Inflight:
+    """
+    One in-flight inference and the callers waiting on it.
+
+    `waiters` and `started` exist to decide what to do when every caller has
+    walked away (all timed out or disconnected):
+
+    - Not started yet: it is still queued for an admission permit, nothing has
+      been spent, and nobody wants the answer. Cancel it, so abandoned work
+      does not occupy a permit that a live request could use.
+    - Already started: the backend call is running in a thread and cannot be
+      interrupted anyway, and its result still populates the cache. Let it
+      finish rather than pay for it and throw the answer away.
+    """
+
+    task: Optional[asyncio.Task] = None
+    waiters: int = 0
+    started: bool = False
 
 
 class RequestBatcher:
@@ -97,9 +120,10 @@ class RequestBatcher:
         # Bounds concurrent backend calls. Holders are the requests actually
         # running inference; deduplicated followers do not consume a permit.
         self._semaphore = asyncio.Semaphore(self.max_concurrent_inferences)
-        # cache_key -> the task computing it. Any later request for the same
-        # key attaches to this task instead of starting a second inference.
-        self._inflight: Dict[str, asyncio.Task] = {}
+        # cache_key -> the in-flight entry computing it. Any later request for
+        # the same key attaches to that entry instead of starting a second
+        # inference.
+        self._inflight: Dict[str, "_Inflight"] = {}
         self._lock = asyncio.Lock()
         self._running = False
 
@@ -147,7 +171,7 @@ class RequestBatcher:
         """
         self._running = False
         async with self._lock:
-            pending = list(self._inflight.values())
+            pending = [e.task for e in self._inflight.values() if e.task is not None]
         if pending:
             await asyncio.gather(*pending, return_exceptions=True)
         logger.info("Batcher stopped")
@@ -206,16 +230,18 @@ class RequestBatcher:
             self.total_requests += 1
 
             async with self._lock:
-                task = self._inflight.get(cache_key)
-                coalesced = task is not None
-                if task is None:
-                    task = asyncio.create_task(
-                        self._execute(cache_key, prompt, temperature, top_p, max_tokens)
+                entry = self._inflight.get(cache_key)
+                coalesced = entry is not None
+                if entry is None:
+                    entry = _Inflight()
+                    self._inflight[cache_key] = entry
+                    entry.task = asyncio.create_task(
+                        self._execute(entry, cache_key, prompt, temperature, top_p, max_tokens)
                     )
-                    self._inflight[cache_key] = task
-                    task.add_done_callback(
+                    entry.task.add_done_callback(
                         functools.partial(self._retire, cache_key)
                     )
+                entry.waiters += 1
 
             span.set_attribute("deduplicated", coalesced)
             if coalesced:
@@ -232,20 +258,45 @@ class RequestBatcher:
 
             # shield: one waiter timing out or disconnecting must not cancel
             # an inference that other waiters are still expecting.
-            if timeout is not None:
-                return await asyncio.wait_for(asyncio.shield(task), timeout=timeout)
-            return await asyncio.shield(task)
+            try:
+                if timeout is not None:
+                    return await asyncio.wait_for(
+                        asyncio.shield(entry.task), timeout=timeout
+                    )
+                return await asyncio.shield(entry.task)
+            finally:
+                await self._release_waiter(entry, cache_key)
+
+    async def _release_waiter(self, entry: "_Inflight", cache_key: str) -> None:
+        """
+        Drop one waiter, and reclaim the inference if it was the last.
+
+        Only work that has not started yet is cancelled -- see _Inflight.
+        """
+        async with self._lock:
+            entry.waiters -= 1
+            if entry.waiters > 0 or entry.started or entry.task.done():
+                return
+            abandoned = entry.task
+
+        abandoned.cancel()
+        ABANDONED_INFERENCES.inc()
+        logger.info(
+            "Cancelled abandoned request before admission",
+            extra={"extra_data": {"cache_key": cache_key[:8]}}
+        )
 
     def _retire(self, cache_key: str, task: asyncio.Task) -> None:
-        """Drop a finished task from the in-flight map. Runs as a done-callback."""
+        """Drop a finished entry from the in-flight map. Runs as a done-callback."""
         current = self._inflight.get(cache_key)
-        if current is task:
+        if current is not None and current.task is task:
             # Mutating a dict from a done-callback is safe: callbacks run on
             # the event loop thread, same as everything that reads it.
             self._inflight.pop(cache_key, None)
 
     async def _execute(
         self,
+        entry: "_Inflight",
         cache_key: str,
         prompt: str,
         temperature: float,
@@ -261,6 +312,9 @@ class RequestBatcher:
         counted_as_waiting = True
         try:
             async with self._semaphore:
+                # Past this point the work is committed: cancelling would not
+                # stop the thread-pool call, and the result is worth caching.
+                entry.started = True
                 self._waiting -= 1
                 counted_as_waiting = False
                 PENDING_REQUESTS.set(self._waiting)

--- a/vgate/metrics.py
+++ b/vgate/metrics.py
@@ -113,6 +113,12 @@ INFLIGHT_INFERENCES = _safe_metric(
     "Number of inferences currently executing on a backend"
 )
 
+ABANDONED_INFERENCES = _safe_metric(
+    Counter,
+    "vgate_abandoned_inferences_total",
+    "Queued inferences cancelled because every waiting caller left before admission"
+)
+
 TOTAL_BATCHES = _safe_metric(
     Counter,
     "vgate_batches_total",

--- a/vgate/metrics.py
+++ b/vgate/metrics.py
@@ -104,7 +104,13 @@ BATCH_QUEUE_TIME = _safe_metric(
 PENDING_REQUESTS = _safe_metric(
     Gauge,
     "vgate_pending_requests",
-    "Number of requests waiting in the batch queue"
+    "Number of requests waiting for an admission permit"
+)
+
+INFLIGHT_INFERENCES = _safe_metric(
+    Gauge,
+    "vgate_inflight_inferences",
+    "Number of inferences currently executing on a backend"
 )
 
 TOTAL_BATCHES = _safe_metric(

--- a/vgate/worker_api.py
+++ b/vgate/worker_api.py
@@ -26,6 +26,7 @@ transport for that method rather than a second API with its own semantics.
 
 import asyncio
 import time
+from contextlib import nullcontext
 from typing import Any, Dict, List
 
 from fastapi import APIRouter, HTTPException
@@ -42,17 +43,28 @@ router = APIRouter(tags=["worker"])
 
 # Set by main.py during lifespan when running with role=worker.
 _engine = None
-# The in-process engines are not safe to call concurrently, which is why the
-# gateway's batcher holds a lock around local backends. That lock lives on the
-# gateway, so once inference moves here the worker has to enforce it itself.
+# Serializes engine access for backends that need it. Which those are is the
+# backend's own declaration, not an assumption made here: AsyncLLMEngine is
+# built to serve concurrent requests, and serializing it would leave the GPU
+# decoding one sequence at a time with continuous batching switched off.
 _inference_lock: asyncio.Lock | None = None
+_serialize_inference = True
 
 
 def set_engine(engine) -> None:
     """Bind the worker's engine. Called once from the app lifespan."""
-    global _engine, _inference_lock
+    global _engine, _inference_lock, _serialize_inference
     _engine = engine
     _inference_lock = asyncio.Lock()
+    backend = getattr(engine, "backend", None)
+    _serialize_inference = not getattr(backend, "supports_concurrent_calls", False)
+    logger.info(
+        "Worker engine bound",
+        extra={"extra_data": {
+            "backend": type(backend).__name__ if backend else None,
+            "serialized": _serialize_inference,
+        }}
+    )
 
 
 class SamplingParams(BaseModel):
@@ -92,9 +104,11 @@ async def internal_generate(request: GenerateRequest) -> GenerateResponse:
 
         started = time.perf_counter()
         try:
-            # Serialize engine access, then run the blocking call off the event
-            # loop so this worker can still answer /health while generating.
-            async with _inference_lock:
+            # Serialize only when the backend requires it, then run the
+            # blocking call off the event loop so this worker can still answer
+            # /health while generating.
+            guard = _inference_lock if _serialize_inference else nullcontext()
+            async with guard:
                 results = await asyncio.get_running_loop().run_in_executor(
                     None, backend.generate, request.prompts, sampling_params
                 )


### PR DESCRIPTION
Replaces the gateway's batching window with deduplication, admission control, and per-request fan-out. Two commits: the rewrite, then the fixes for the throughput regression and abandonment policy raised in review.

## Why the window had to go

**vLLM and SGLang already batch, and do it better.** They can admit a request into a batch that is already decoding; a sealed Python-side window cannot. The gateway window was competing with the engine's scheduler rather than feeding it.

**A sealed batch is routed as a unit.** Every request in it lands on the same worker regardless of load, so load-aware routing was impossible — least-inflight would have been choosing between workers on a signal it could not act on at that granularity.

Three things survived, because they were never really about batching:

- **Deduplication**, now stronger: coalescing follows the in-flight request rather than a window, so identical requests merge however far apart they arrive.
- **Admission control**, which is what `max_batch_size` now expresses.
- **Fan-out**: one backend call per request, so a router sees one decision each.

## Review fix 1 — throughput regression

The regression was real, and traced back to a wrong assumption made two changes earlier that fan-out then amplified.

The worker held an **unconditional** lock around every inference, added on the premise that "in-process engines are not safe to call concurrently". That is false for the backend in use: `VLLMBackend.generate()` bridges into `AsyncLLMEngine`'s loop and submits every prompt with `asyncio.gather`; the engine interleaves them via continuous batching. Serializing it switches that off.

Under batching the lock was survivable — a batch of 8 entered the engine as one call and vLLM still interleaved the 8 inside it. Fan-out made each call carry one prompt:

```
batching + lock : 8 prompts per call -> 8 sequences in flight
fan-out  + lock : 1 prompt  per call -> 1 sequence  in flight
```

Concurrency is now the backend's declaration rather than an assumption. `VLLMBackend` and `DryRunBackend` declare `supports_concurrent_calls`; the worker serializes only backends that do not. `SGLangBackend` deliberately does not — that adapter has never run against a live engine, so it stays serialized until measured.

**Measured**: 16 requests at 50ms, admission limit 8 — **0.817s serialized vs 0.104s concurrent (7.84x)**, against an ideal of 0.100s. End to end, 8 concurrent requests to a worker with 100ms simulated latency took **131ms** where serialization would have taken ~864ms.

## Review fix 2 — abandonment policy

Previously a timed-out request kept running with no stated rule. The policy is now explicit and depends on whether the work was admitted:

| State | On last caller leaving | Why |
|---|---|---|
| Queued, not admitted | **Cancelled** | Nothing spent, and it would hold a permit a live request could use |
| Already running | **Runs to completion** | The thread-pool call cannot be interrupted anyway, and its result populates the cache |

Reclamation counts waiters, so one caller timing out never cancels work another is still waiting for. Counted in `vgate_abandoned_inferences_total`, documented in README.

## Config semantics changed

`max_batch_size` keeps its key but now bounds concurrency instead of window size — an existing config loads and behaves differently, so README and `config.yaml` call it out. `max_wait_time_ms` is accepted and ignored; the startup log reports the value it ignores.

## Verification

Two live workers, 8 concurrent requests: **8 separate backend calls, split 4/4, each carrying exactly one prompt** — under the old model they would have been sealed into one or two batches on a single worker. Five identical concurrent requests produced **one** backend call.

`tests/` **226 passed**, `vgate-client/tests/` **74 passed**. New tests cover per-request dispatch, dedup outside any time window, failure propagation to all waiters, failures not poisoning the cache, followers not consuming admission permits, the serialization opt-out, and all three abandonment cases.

## Not included

least-inflight and EWMA routing. Unblocked by this change, but keeping them out leaves this diff to the one risky part — the online serving path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)