### PR TITLE
feat: give a client request a deadline

### DIFF
--- a/README.md
+++ b/README.md
@@ -983,7 +983,7 @@ work that is now overdue rather than upcoming.
 - [ ] Unify streaming and non-streaming admission control
 - [ ] Add bounded queues, deadlines, and stable overload responses
 - [ ] Abort backend work on client cancellation instead of computing orphaned tokens
-- [ ] Add request timeouts and per-backend error classification
+- [~] Add request timeouts and per-backend error classification — a request deadline (`reliability.request_timeout_seconds`, default 120s) now bounds the admission wait as well as the inference, returning `504`; per-backend error classification exists for worker calls (connect vs mid-flight vs non-200) but not as a general scheme
 - [ ] Make gateway readiness reflect whether it can serve — `/health` returns `ok` without consulting the worker registry, so Kubernetes routes traffic to a gateway holding zero healthy workers and those requests get `503`
 - [ ] Drain in-flight work on worker shutdown — the gateway addresses pods directly, so removing a pod from a Service's endpoints does not stop traffic to it; a terminating worker must fail its own `/health` while still finishing what it has
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,7 @@ Current gaps:
 - Container images are referenced by version tag (`vgate:0.3.2-cpu`, `vgate:0.3.2-gpu`), not by digest. A tag is a convention the registry does not enforce, so it is weaker than it looks; digest pinning plus a release process that produces them is not done.
 - DNS resolution is not interruptible. Discovery runs `getaddrinfo` on a dedicated single-thread executor with a bounded await, so a hung resolver cannot stall health probing or take a thread from the default executor that `RequestBatcher` uses for inference. It still cannot be cancelled: abandoning the future leaves the OS call blocked until it returns on its own, so membership refresh is paused rather than broken while that happens. Making resolution genuinely interruptible needs an async resolver (`aiodns` or similar), which is a new dependency and is not taken on yet.
 - The gateway's readiness probe does not reflect whether it can serve. `/health` returns `ok` unconditionally, without consulting the worker registry, so Kubernetes marks a gateway Ready and routes traffic to it while it holds zero healthy workers — those requests get `503`. The kind run makes this visible: both workers record an extra removed/recovered pair at cold start, because the gateway begins probing before any worker is up. Splitting liveness from readiness (a `/ready` that fails when no worker is in rotation) is not done, and cannot simply reuse `/health`, which the worker health checker polls with different intent.
-- Backpressure, request timeout, circuit breaking, and worker failure handling are incomplete.
+- Backpressure is incomplete. A request deadline exists (`reliability.request_timeout_seconds`, default 120s) and bounds the admission wait as well as the inference, so the queue is bounded in *time*; it is not bounded in *length*, and there is no load shedding, so an overloaded gateway still accepts work it will only ever answer with 504. Circuit breaking beyond health-based worker removal is also not done.
 - The embedding endpoint is currently a mock MVP implementation.
 - C++/CUDA lower-level performance work (Phase 7-8) is deliberately gated behind measured bottlenecks and has not been started.
 
@@ -384,11 +384,11 @@ Reason: reliable infrastructure must define what happens under overload. Batchin
 
 Tasks:
 
-1. Add maximum queue length.
-2. Add queue timeout.
+1. Add maximum queue length. **Not done.** The queue is bounded in time but not in length: a request cannot wait forever, but nothing rejects the thousandth waiter.
+2. [x] Add queue timeout. `reliability.request_timeout_seconds` bounds one client request end to end, covering the wait for an admission permit as well as the inference, and returns `504`. `RequestBatcher.submit()` had accepted a deadline since it was written; nothing passed one, so this was dead machinery until now.
 3. Handle request cancellation.
 4. Add load shedding.
-5. Define 429/503 behavior.
+5. [~] Define 429/503/504 behavior. 429 is per-key rate limiting, 503 with `Retry-After` is "no healthy workers", and 504 is a request that missed its own deadline. What is missing is 503 for shedding, which needs a bounded queue to shed from.
 6. Improve graceful shutdown.
 7. Add overload metrics.
 8. Split readiness from liveness on the gateway. `/health` currently returns `ok`

--- a/config.yaml
+++ b/config.yaml
@@ -82,6 +82,25 @@ model:
   enforce_eager: true
   engine_type: "vllm"  # "vllm" or "sglang" / 推理后端引擎
 
+# Reliability / 可靠性
+#
+# request_timeout_seconds bounds a single client request end to end, covering
+# the wait for an admission permit as well as the inference. Without it a
+# request queues indefinitely -- the batcher has always supported a deadline,
+# but nothing supplied one.
+#
+# It intentionally matches worker.timeout_seconds. When the gateway forwards to
+# workers, the worker's own timeout usually fires first and gives a more
+# specific error; what this adds is a bound on the queue wait, which starts
+# before the request is ever sent and so is not covered there.
+#
+# Exceeding it returns 504 (this request did not finish), not 503 (the service
+# cannot take work) -- clients act on those differently. Set to 0 to disable.
+#
+# Bounded queues and load shedding are NOT implemented; see ROADMAP.md Phase 3.
+reliability:
+  request_timeout_seconds: 120.0
+
 # Request batching / 请求批处理
 batch:
   # Maximum concurrent inferences (admission control).

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ from vgate.batcher import RequestBatcher
 from vgate.logging_config import setup_logging, get_logger
 from vgate.metrics import (
     REQUEST_COUNT, REQUEST_LATENCY, REQUEST_IN_PROGRESS,
-    TOKENS_GENERATED, INFERENCE_ERRORS,
+    TOKENS_GENERATED, INFERENCE_ERRORS, REQUEST_TIMEOUTS,
     STREAM_TTFT, STREAM_TPOT, STREAM_DURATION, STREAM_TOKENS, STREAM_REQUESTS,
     init_app_info
 )
@@ -445,11 +445,17 @@ async def create_chat_completion(request: ChatCompletionRequest):
         prompt = messages_to_prompt(request.messages)
 
         # Submit to batcher for batched processing
+        # A deadline covering the admission wait as well as the inference.
+        # submit() has always accepted one; nothing passed it, so a request
+        # could wait indefinitely for a permit and no configuration could stop
+        # it. 0 disables, restoring that behaviour explicitly.
+        timeout = config.reliability.request_timeout_seconds or None
         response = await batcher.submit(
             prompt,
             max_tokens=request.max_tokens,
             temperature=request.temperature,
-            top_p=request.top_p
+            top_p=request.top_p,
+            timeout=timeout,
         )
 
         # Adapt engine's response to OpenAI-like format
@@ -474,6 +480,32 @@ async def create_chat_completion(request: ChatCompletionRequest):
                 "total_tokens": response.get("total_tokens", 0) + response.get("prompt_tokens", 0),
             },
         }
+    except asyncio.TimeoutError:
+        # 504, not 503. The two say different things and clients act on them
+        # differently: 503 with Retry-After means "capacity is unavailable,
+        # come back", while 504 means this request was accepted and the work
+        # behind it did not finish in time. Retry-After is deliberately absent
+        # -- nothing here knows that retrying sooner would help.
+        #
+        # The inference itself is not necessarily cancelled. If no other caller
+        # is waiting on it and it has not started, it is abandoned; if it has
+        # started it runs to completion, because a thread-pool call cannot be
+        # interrupted and its result still populates the cache. See
+        # RequestBatcher's abandonment policy.
+        REQUEST_TIMEOUTS.inc()
+        app_logger.warning(
+            "Request exceeded its deadline",
+            extra={"extra_data": {
+                "timeout_seconds": config.reliability.request_timeout_seconds,
+            }}
+        )
+        raise HTTPException(
+            status_code=504,
+            detail=(
+                "Request did not complete within "
+                f"{config.reliability.request_timeout_seconds}s"
+            ),
+        )
     except NoHealthyWorkersError as e:
         # Every worker is out of rotation. This is capacity unavailable, not a
         # bad request or a gateway bug, so it is a 503 with Retry-After rather

--- a/tests/test_request_timeout.py
+++ b/tests/test_request_timeout.py
@@ -1,0 +1,249 @@
+# Copyright 2025 the V-Gate authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The request deadline.
+
+RequestBatcher.submit() has accepted a timeout since it was written, and
+nothing ever passed one -- the parameter had tests, the production path did
+not use it, and a request could wait for an admission permit indefinitely. The
+tests here are about that wiring and about which HTTP status it produces.
+"""
+
+import asyncio
+
+import pytest
+
+from vgate.batcher import RequestBatcher
+from vgate.config import ReliabilityConfig
+
+
+class SlowBackend:
+    """A backend whose every call takes longer than any deadline under test."""
+
+    supports_concurrent_calls = False  # forces admission to one at a time
+
+    def __init__(self, delay=5.0):
+        self.delay = delay
+        self.calls = 0
+
+    def create_sampling_params(self, temperature, top_p, max_tokens):
+        return {"temperature": temperature, "top_p": top_p, "max_tokens": max_tokens}
+
+    def generate(self, prompts, sampling_params):
+        self.calls += 1
+        import time
+        time.sleep(self.delay)
+        return [{"text": "slow", "token_ids": [1], "num_tokens": 1, "metrics": {}}
+                for _ in prompts]
+
+
+class SlowEngine:
+    def __init__(self, delay=5.0):
+        self.backend = SlowBackend(delay)
+
+    def chat_completions_batch(self, prompts, max_tokens=256, temperature=0.7, top_p=0.9):
+        return self.backend.generate(prompts, None)
+
+
+@pytest.fixture
+async def batcher():
+    b = RequestBatcher(engine=SlowEngine())
+    await b.start()
+    yield b
+    b._running = False
+
+
+# --------------------------------------------------------------------------
+# Config
+# --------------------------------------------------------------------------
+
+def test_default_matches_the_worker_timeout():
+    """
+    Not an arbitrary number. The gateway's deadline lines up with the timeout
+    it applies to a worker call, so the two do not disagree about how long a
+    request is allowed to take.
+    """
+    from vgate.config import WorkerConfig
+    assert ReliabilityConfig().request_timeout_seconds == WorkerConfig().timeout_seconds
+
+
+def test_zero_disables_the_deadline():
+    """`or None` in the request path turns 0 into "no timeout"."""
+    assert (ReliabilityConfig(request_timeout_seconds=0).request_timeout_seconds or None) is None
+
+
+def test_a_negative_deadline_is_rejected():
+    with pytest.raises(ValueError, match="must be >= 0"):
+        ReliabilityConfig(request_timeout_seconds=-1)
+
+
+# --------------------------------------------------------------------------
+# Behaviour
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_the_deadline_covers_the_wait_for_a_permit():
+    """
+    The point of the change. A request that never reaches the backend -- because
+    something else holds the only admission permit -- must still time out.
+    Bounding the inference alone would leave the queue unbounded in time, which
+    is exactly the state this fixes.
+    """
+    b = RequestBatcher(engine=SlowEngine(delay=3.0))
+    await b.start()
+    try:
+        # Occupies the single permit for the whole test.
+        blocker = asyncio.create_task(b.submit("blocking prompt"))
+        await asyncio.sleep(0.2)
+
+        started = asyncio.get_running_loop().time()
+        with pytest.raises(asyncio.TimeoutError):
+            await b.submit("queued behind the blocker", timeout=0.3)
+        waited = asyncio.get_running_loop().time() - started
+
+        assert waited < 1.5, f"waited {waited:.1f}s; the deadline did not cover the queue"
+        blocker.cancel()
+        await asyncio.gather(blocker, return_exceptions=True)
+    finally:
+        b._running = False
+
+
+@pytest.mark.asyncio
+async def test_no_deadline_means_the_request_waits():
+    """The disabled case still behaves as it did, rather than silently capping."""
+    b = RequestBatcher(engine=SlowEngine(delay=0.4))
+    await b.start()
+    try:
+        result = await b.submit("unbounded", timeout=None)
+        assert result["text"] == "slow"
+    finally:
+        b._running = False
+
+
+@pytest.mark.asyncio
+async def test_a_timed_out_request_does_not_cancel_work_others_need():
+    """
+    Abandonment policy, restated because the deadline is what now triggers it:
+    a caller giving up must not cancel an inference another caller is still
+    waiting on, and must not discard a result already being paid for.
+    """
+    b = RequestBatcher(engine=SlowEngine(delay=0.6))
+    await b.start()
+    try:
+        patient = asyncio.create_task(b.submit("shared prompt"))
+        await asyncio.sleep(0.1)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await b.submit("shared prompt", timeout=0.2)
+
+        assert (await patient)["text"] == "slow", "the impatient caller killed shared work"
+    finally:
+        b._running = False
+
+
+# --------------------------------------------------------------------------
+# HTTP surface
+# --------------------------------------------------------------------------
+
+def test_exceeding_the_deadline_returns_504_not_503():
+    """
+    The status code is the part clients act on, and 503 and 504 mean different
+    things. 503 with Retry-After says capacity is unavailable -- back off and
+    come back. 504 says this particular request was accepted and the work
+    behind it did not finish in time; nothing here knows that retrying sooner
+    would help, so no Retry-After is offered.
+
+    Sharing one code for both would leave a client unable to tell "the pool is
+    down" from "my request was slow".
+    """
+    import main
+    from fastapi.testclient import TestClient
+
+    class TimingOutBatcher:
+        async def submit(self, *args, **kwargs):
+            raise asyncio.TimeoutError()
+
+        async def start(self):
+            pass
+
+        async def stop(self):
+            pass
+
+    original = main.batcher
+    main.batcher = TimingOutBatcher()
+    try:
+        with TestClient(main.app) as client:
+            main.batcher = TimingOutBatcher()  # lifespan replaces it on startup
+            response = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "test",
+                    "messages": [{"role": "user", "content": "will not finish"}],
+                    "max_tokens": 8,
+                },
+            )
+    finally:
+        main.batcher = original
+
+    assert response.status_code == 504, response.text
+    assert "Retry-After" not in response.headers, (
+        "504 must not advertise a retry delay; nothing here knows one"
+    )
+
+
+def test_the_request_path_passes_the_configured_deadline():
+    """
+    The wiring itself, which is all this change actually is.
+
+    Written after a negative test exposed the gap: removing `timeout=timeout`
+    from the request path broke nothing, because the batcher tests supply their
+    own deadline and the status-code test uses a stub that raises regardless.
+    Both passed against a gateway that had gone back to waiting forever.
+    """
+    import main
+    from fastapi.testclient import TestClient
+
+    seen = {}
+
+    class RecordingBatcher:
+        async def submit(self, *args, **kwargs):
+            seen["timeout"] = kwargs.get("timeout", "<not passed>")
+            return {"text": "ok", "total_tokens": 1, "prompt_tokens": 0}
+
+        async def start(self):
+            pass
+
+        async def stop(self):
+            pass
+
+    original = main.batcher
+    try:
+        with TestClient(main.app) as client:
+            main.batcher = RecordingBatcher()
+            client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "test",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 8,
+                },
+            )
+    finally:
+        main.batcher = original
+
+    assert seen["timeout"] == main.config.reliability.request_timeout_seconds, (
+        f"request path supplied {seen['timeout']!r}; a deadline that never "
+        "reaches submit() leaves the queue unbounded in time"
+    )

--- a/vgate/config.py
+++ b/vgate/config.py
@@ -121,6 +121,35 @@ class ModelConfig(BaseModel):
         return v
 
 
+class ReliabilityConfig(BaseModel):
+    """
+    How the service behaves when it cannot keep up.
+
+    Only the request deadline exists so far. Bounded queues and load shedding
+    belong here too and are not implemented -- see ROADMAP.md Phase 3.
+    """
+    # Upper bound on how long one client request may take, covering BOTH the
+    # wait for an admission permit and the inference itself. Without it a
+    # request waits indefinitely: RequestBatcher.submit() has always accepted a
+    # timeout, but nothing passed one, so the queue was unbounded in time as
+    # well as in length.
+    #
+    # Defaults to worker.timeout_seconds. For a gateway forwarding to workers
+    # the worker's own timeout usually fires first and produces a more specific
+    # error; what this adds is a bound on the queue wait, which the worker
+    # timeout does not cover because it only starts once the request is sent.
+    #
+    # Set to 0 to disable, restoring the previous unbounded behaviour.
+    request_timeout_seconds: float = 120.0
+
+    @field_validator("request_timeout_seconds")
+    @classmethod
+    def validate_timeout(cls, v: float) -> float:
+        if v < 0:
+            raise ValueError("request_timeout_seconds must be >= 0 (0 disables)")
+        return v
+
+
 class BatchConfig(BaseModel):
     """Request batching configuration."""
     max_batch_size: int = 8
@@ -259,6 +288,7 @@ class VGateConfig(BaseSettings):
     worker: WorkerConfig = Field(default_factory=WorkerConfig)
     model: ModelConfig = Field(default_factory=ModelConfig)
     batch: BatchConfig = Field(default_factory=BatchConfig)
+    reliability: ReliabilityConfig = Field(default_factory=ReliabilityConfig)
     cache: CacheConfig = Field(default_factory=CacheConfig)
     inference: InferenceConfig = Field(default_factory=InferenceConfig)
     logging: LoggingConfig = Field(default_factory=LoggingConfig)

--- a/vgate/metrics.py
+++ b/vgate/metrics.py
@@ -119,6 +119,12 @@ ABANDONED_INFERENCES = _safe_metric(
     "Queued inferences cancelled because every waiting caller left before admission"
 )
 
+REQUEST_TIMEOUTS = _safe_metric(
+    Counter,
+    "vgate_request_timeouts_total",
+    "Client requests that exceeded reliability.request_timeout_seconds"
+)
+
 TOTAL_BATCHES = _safe_metric(
     Counter,
     "vgate_batches_total",


### PR DESCRIPTION
First of the wrap-up fixes: close the gap between machinery that exists and machinery that runs.

## The gap

```
batcher.submit(..., timeout=None)   ← parameter exists, has tests
main.py:448  batcher.submit(...)    ← never passed one
```

A request could wait for an admission permit **indefinitely**, and no configuration could stop it. The feature existed everywhere except where it would have taken effect.

## What it does

`reliability.request_timeout_seconds` bounds one client request **end to end** — and end to end is the point. The deadline covers the wait for a permit, not just the inference; bounding the inference alone would leave the queue unbounded in time, which is the actual state being fixed.

Default is `worker.timeout_seconds` rather than an arbitrary number, so the gateway and the worker call it applies do not disagree about how long a request may take. For a gateway forwarding to workers the worker's own timeout usually fires first and gives a more specific error; what this adds is the bound on **queue wait**, which starts before the request is sent and so is not covered there. `0` disables it — restoring the old behaviour explicitly rather than by omission.

## 504, not 503

| Code | Means | Client should |
|---|---|---|
| `429` | you are sending too much | back off yourself |
| `503` + `Retry-After` | capacity unavailable | come back later |
| **`504`** | **accepted, but did not finish in time** | **nothing here knows retrying helps** |

No `Retry-After` on the 504, deliberately. Sharing one code across these would leave a client unable to tell *"the pool is down"* from *"my request was slow"*.

A timed-out caller does not cancel work others need — the existing abandonment policy still holds: a shared inference survives one waiter leaving, and a started inference runs to completion because its result is already paid for and populates the cache.

## The negative pass found a gap in my tests, not a confirmation

Deleting `timeout=timeout` from the request path **broke nothing**. The batcher tests supply their own deadline; the status-code test uses a stub that raises regardless. Both passed against a gateway that had gone back to waiting forever — the exact regression this PR exists to prevent.

Added a test for the wiring itself, and verified it fails against that deletion:

```
E  AssertionError: request path supplied '<not passed>'; a deadline that never
   reaches submit() leaves the queue unbounded in time
```

## Still not done

The queue is bounded in **time**, not in **length**. Nothing rejects the thousandth waiter, and there is no load shedding — an overloaded gateway still accepts work it will only ever answer with 504. README and ROADMAP say that rather than implying Phase 3 is finished.

---

275 server tests + 74 client tests passing; manifest invariants unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)